### PR TITLE
fix: resolve gosec G117 by unexporting secret-related config fields (Closes #30)

### DIFF
--- a/providers/aws.go
+++ b/providers/aws.go
@@ -22,8 +22,8 @@ type AWSProvider struct {
 // AWSConfig holds the configuration for the AWS Secrets Manager client
 type AWSConfig struct {
 	Region    string
-	AccessKey string
-	SecretKey string
+        accessKey string
+        secretKey string
 	Profile   string
 }
 
@@ -31,8 +31,8 @@ type AWSConfig struct {
 func (a *AWSProvider) Initialize(config map[string]string) error {
 	a.config = &AWSConfig{
 		Region:    getConfigOrDefault(config, "AWS_REGION", "us-east-1"),
-		AccessKey: config["AWS_ACCESS_KEY_ID"],
-		SecretKey: config["AWS_SECRET_ACCESS_KEY"],
+		accessKey: config["AWS_ACCESS_KEY_ID"],
+		secretKey: config["AWS_SECRET_ACCESS_KEY"],
 		Profile:   config["AWS_PROFILE"],
 	}
 
@@ -143,11 +143,11 @@ func (a *AWSProvider) loadAWSConfig() (aws.Config, error) {
 	}
 
 	// Override with explicit credentials if provided
-	if a.config.AccessKey != "" && a.config.SecretKey != "" {
+	if a.config.accessKey != "" && a.config.secretKey != "" {
 		cfg.Credentials = aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
 			return aws.Credentials{
-				AccessKeyID:     a.config.AccessKey,
-				SecretAccessKey: a.config.SecretKey,
+				AccessKeyID:     a.config.accessKey,
+				SecretAccessKey: a.config.secretKey,
 			}, nil
 		})
 	}

--- a/providers/openbao.go
+++ b/providers/openbao.go
@@ -27,7 +27,7 @@ type OpenBaoConfig struct {
 	AuthMethod string
 	CACert     string
 	ClientCert string
-	ClientKey  string
+        clientKey  string
 }
 
 // Initialize sets up the OpenBao provider with the given configuration
@@ -41,7 +41,7 @@ func (o *OpenBaoProvider) Initialize(config map[string]string) error {
 		AuthMethod: getConfigOrDefault(config, "OPENBAO_AUTH_METHOD", "token"),
 		CACert:     config["OPENBAO_CACERT"],
 		ClientCert: config["OPENBAO_CLIENT_CERT"],
-		ClientKey:  config["OPENBAO_CLIENT_KEY"],
+		clientKey:  config["OPENBAO_CLIENT_KEY"],
 	}
 
 	// Configure OpenBao client (using OpenBao API client since OpenBao is compatible)
@@ -53,7 +53,7 @@ func (o *OpenBaoProvider) Initialize(config map[string]string) error {
 		tlsConfig := &api.TLSConfig{
 			CACert:     o.config.CACert,
 			ClientCert: o.config.ClientCert,
-			ClientKey:  o.config.ClientKey,
+			ClientKey:  o.config.clientKey,
 		}
 		if err := openBaoConfig.ConfigureTLS(tlsConfig); err != nil {
 			return fmt.Errorf("failed to configure TLS: %v", err)

--- a/providers/vault.go
+++ b/providers/vault.go
@@ -27,7 +27,7 @@ type SecretsConfig struct {
 	AuthMethod string
 	CACert     string
 	ClientCert string
-	ClientKey  string
+        clientKey string 
 }
 
 // Initialize sets up the Vault provider with the given configuration
@@ -41,7 +41,7 @@ func (v *VaultProvider) Initialize(config map[string]string) error {
 		AuthMethod: getConfigOrDefault(config, "VAULT_AUTH_METHOD", "token"),
 		CACert:     config["VAULT_CACERT"],
 		ClientCert: config["VAULT_CLIENT_CERT"],
-		ClientKey:  config["VAULT_CLIENT_KEY"],
+		clientKey:  config["VAULT_CLIENT_KEY"],
 	}
 
 	// Configure Vault client
@@ -53,7 +53,7 @@ func (v *VaultProvider) Initialize(config map[string]string) error {
 		tlsConfig := &api.TLSConfig{
 			CACert:     v.config.CACert,
 			ClientCert: v.config.ClientCert,
-			ClientKey:  v.config.ClientKey,
+			ClientKey:  v.config.clientKey,
 		}
 		if err := SecretsConfig.ConfigureTLS(tlsConfig); err != nil {
 			return fmt.Errorf("failed to configure TLS: %v", err)


### PR DESCRIPTION
Fixes gosec G117 CI failure by unexporting secret-related config fields in AWS, Vault, and OpenBao providers and updating internal references.

Closes #30