### PR TITLE
fix: avoid error shadowing in secret update error handling

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -426,8 +426,8 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 	log.Printf("Created new version of secret %s with name %s and ID: %s", secretName, newSecretName, createResponse.ID)
 
 	// Update all services that use this secret to point to the new version
-    if err := d.updateServicesSecretReference(secretName, newSecretName, createResponse.ID); err != nil {
-	    // try to remove the new secret since service update failed
+	if err := d.updateServicesSecretReference(secretName, newSecretName, createResponse.ID); err != nil {
+		// try to remove the new secret since service update failed
 		if cleanupErr := d.dockerClient.SecretRemove(ctx, createResponse.ID); cleanupErr != nil {
 			log.Warnf("failed to remove new secret %s after service update error: %v", createResponse.ID, cleanupErr)
 		}


### PR DESCRIPTION
When reviewing the update flow, I noticed that if the service update failed, we attempted to clean up the newly created secret using the same err variable.

If the update failed and the cleanup succeeded (returned nil), the original error would be overwritten and we could end up returning <nil> instead of the real failure.

This change uses a separate cleanupErr variable so that the original update error is preserved and always returned, while cleanup errors are handled independently.

```bash
if err := updateService(); err != nil {
    err := cleanup()
    return fmt.Errorf("failed: %v", err)
}
```

Output:

```bash
failed: <nil>
```

```bash
if err := updateService(); err != nil {
    if cleanupErr := cleanup(); cleanupErr != nil {
        log.Warn(cleanupErr)
    }
    return fmt.Errorf("failed: %v", err)
}
```

Output:

```bash
failed: update out of sequence
```