### PR TITLE
fix: prevent secret name collision by using nanosecond precision

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -406,7 +406,7 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 	}
 
 	// Generate a unique name for the new secret version
-	newSecretName := fmt.Sprintf("%s-%d", secretName, time.Now().Unix())
+	newSecretName := fmt.Sprintf("%s-%d", secretName, time.Now().UnixNano())
 
 	// Create new secret with versioned name and same labels but updated value
 	newSecretSpec := swarm.SecretSpec{


### PR DESCRIPTION
Previously, the secret name was generated using time in seconds.
If two rotations happened within the same second, both would produce the same name, and the operation would fail with an error saying the secret already exists.

Now, the name uses time in nanoseconds, which provides much higher precision.
Even if rotations happen very close together, each generated name will be unique.

```bash
 newSecretName := fmt.Sprintf("%s-%d", secretName, time.Now().Unix())

Rotation 1 at 12:00:05.100
Rotation 2 at 12:00:05.700

Generated names:
mysecret-1708756805
mysecret-1708756805
```
Output

```bash
Error: secret mysecret-1708756805 already exists
```
 ```bash
newSecretName := fmt.Sprintf("%s-%d", secretName, time.Now().UnixNano())

Generated names:
mysecret-1708756805100000000
mysecret-1708756805700000000
```
Output

```bash
No collision
Secret creation succeeds
```
