### PR TITLE
fix: handle versioned secret names during rotation

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -463,12 +463,8 @@ func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretNa
 		updatedSecrets := make([]*swarm.SecretReference, len(service.Spec.TaskTemplate.ContainerSpec.Secrets))
 
 		for i, secretRef := range service.Spec.TaskTemplate.ContainerSpec.Secrets {
-			log.Printf("rotation check: oldSecret=%s serviceSecret=%s",
-                oldSecretName, secretRef.SecretName)
 			if secretRef.SecretName == oldSecretName ||
 				strings.HasPrefix(secretRef.SecretName, oldSecretName+"-") {
-				log.Printf("rotation update: old=%s new=%s",
-                    oldSecretName, newSecretName)
 				// Update to use the new secret name and ID
 				updatedSecrets[i] = &swarm.SecretReference{
 					File:       secretRef.File,


### PR DESCRIPTION
While I was reviewing the rotation flow, I noticed that versioned secret names weren’t being matched consistently, which could cause silent update skips.


```bash
Initial secret:        db-password
After first rotation:  db-password-1111
Service references:    db-password-1111

Next rotation checks for:
oldSecretName = db-password
```
Output

```bash
Exact match fails
Service is not updated
Rotation is silently skipped
```
```bash
Initial secret:        db-password
After first rotation:  db-password-1111
Service references:    db-password-1111

Next rotation checks for:
oldSecretName = db-password
```
Output

```bash
Prefix match succeeds
Service updated to db-password-2222
Rotation proceeds correctly
```