### PR TITLE
fix: prevent panic by rejecting non-positive durations

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -16,10 +16,11 @@ func getEnvOrDefault(key, defaultValue string) string {
 
 // parseDurationOrDefault parses duration string or returns default
 func parseDurationOrDefault(durationStr string) time.Duration {
-	if duration, err := time.ParseDuration(durationStr); err == nil {
-		return duration
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil || duration <= 0 {
+		return 5 * time.Minute
 	}
-	return 5 * time.Minute // Default to 5 minutes
+	return duration
 }
 
 // parseIntOrDefault parses integer string or returns default


### PR DESCRIPTION
The function previously allowed negative durations like -10m. While Go accepts this during parsing, using such a value with time.NewTicker causes a runtime panic because Go does not allow zero or negative intervals. This means a simple configuration mistake could crash the application.

The fix adds a small validation check to ensure only positive durations are returned. If the value is invalid or non-positive, it safely falls back to the default (5 minutes), preventing crashes while keeping valid behavior unchanged.

```bash
INTERVAL=-10m
```
Old behavior
```bash
Parsed interval: -10m0s
panic: non-positive interval for NewTicker
exit status 2
```
New behaviour 
```bash
Parsed interval: 5m0s
Ticker created successfully
```
