### PR TITLE
fix: avoid taking address of range variable when locating existing se…

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -394,13 +394,13 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 	}
 
 	var existingSecret *swarm.Secret
-	for _, secret := range secrets {
+	for i := range secrets {
+		secret := &secrets[i]
 		if secret.Spec.Name == secretName {
-			existingSecret = &secret
+			existingSecret = secret
 			break
 		}
 	}
-
 	if existingSecret == nil {
 		return fmt.Errorf("secret %s not found", secretName)
 	}


### PR DESCRIPTION
```bash
secrets = ["A", "B", "C"]
update secrets[1] = "MODIFIED"
print(ptr.Name)
```
Output
```bash
B
```
While iterating with for _, secret := range secrets, the variable secret is a temporary copy created in each loop iteration.
The pointer was storing the address of this temporary copy, not the actual element inside the slice.
So when the real slice element was modified, the pointer still pointed to the old copied value
```bash
secrets = ["A", "B", "C"]
update secrets[1] = "MODIFIED"
print(ptr.Name)
```
Output
```bash
MODIFIED
```
Now the pointer directly stores the address of the real element inside the slice (&secrets[i]).
So when the slice element is updated, the pointer reflects the change correctly.