### PR TITLE
fix: secret rotation failure after first update by handling versioned secret names

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -457,12 +457,16 @@ func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretNa
 	var updatedServices []string
 
 	for _, service := range services {
+		containerSpec := service.Spec.TaskTemplate.ContainerSpec
+		if containerSpec == nil || len(containerSpec.Secrets) == 0 {
+			continue
+		}
 		// Check if service uses this secret and update the reference
 		needsUpdate := false
-		updatedSecrets := make([]*swarm.SecretReference, len(service.Spec.TaskTemplate.ContainerSpec.Secrets))
+		updatedSecrets := make([]*swarm.SecretReference, len(containerSpec.Secrets))
 
-		for i, secretRef := range service.Spec.TaskTemplate.ContainerSpec.Secrets {
-			if secretRef.SecretName == oldSecretName {
+		for i, secretRef := range containerSpec.Secrets {
+			if strings.HasPrefix(secretRef.SecretName, oldSecretName) {
 				// Update to use the new secret name and ID
 				updatedSecrets[i] = &swarm.SecretReference{
 					File:       secretRef.File,


### PR DESCRIPTION
Bug:
Secret rotation worked only once. After the first update, further rotations silently failed.

Example:

Initial value = A

1st rotation:
A → B
Docker creates: mysecret-123
Service updates
Container uses B

2nd rotation:
B → C
Docker creates: mysecret-456
Service still uses: mysecret-123

The system was looking for a secret named exactly "mysecret".
After rotation, Docker renamed it to "mysecret-123".

Since the name was different, the system did not realize it was the same secret.
So it did not update the service.

The container kept using the old value.
No error was shown.
Fix:
Replaced exact name comparison with:
strings.HasPrefix(secretRef.SecretName, oldSecretName)

Now versioned secrets (mysecret-123, mysecret-456) are correctly identified as belonging to the original secret. The service updates on every rotation.

Result:
Provider = Docker = Container
Rotation works reliably across multiple updates.