### PR TITLE
fix: refactor function and response field names for secret reuse clarity

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -154,18 +154,21 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 		d.trackSecret(req, value)
 	}
 
-	// Determine if secret should be reusable
-	doNotReuse := d.shouldNotReuse(req)
+	// Determine whether the caller should request a freshly issued secret.
+	createSecret := d.shouldCreateSecret(req)
 
 	log.Printf("Successfully returning secret value")
 	return secrets.Response{
-		Value:      value,
-		DoNotReuse: doNotReuse,
+		Value: value,
+		// Docker's plugin API uses DoNotReuse. We map from the clearer
+		// local "create secret" decision to preserve wire compatibility.
+		DoNotReuse: createSecret,
 	}
 }
 
-// shouldNotReuse determines if the secret should not be reused
-func (d *SecretsDriver) shouldNotReuse(req secrets.Request) bool {
+// shouldCreateSecret determines whether a new secret should be issued
+// for this request instead of reusing a previously returned value.
+func (d *SecretsDriver) shouldCreateSecret(req secrets.Request) bool {
 	// Check for explicit label
 	if reuse, exists := req.SecretLabels["vault_reuse"]; exists {
 		return strings.ToLower(reuse) == "false"


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change 
ex: - [x] Refactor
-->

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Mention the secrets provider 

## Description

This pull request refactors the logic for determining whether a secret should be freshly issued or reused in the `SecretsDriver`. The main change is a renaming and clarification of the method and variable names to better reflect their purpose, while maintaining compatibility with Docker's plugin API.

Refactoring for clarity:

* Renamed the method `shouldNotReuse` to `shouldCreateSecret` and updated its description to clarify that it determines whether a new secret should be issued instead of reusing an existing one. (`driver.go`)
* Updated the variable name from `doNotReuse` to `createSecret` and improved the comment to explain the mapping between local logic and Docker's API field. (`driver.go`)
* Replaced the use of `doNotReuse` with `createSecret` in the returned `secrets.Response`, preserving wire compatibility. (`driver.go`)

## Commands & Configuration to test

N/A

## Screenshots & Logs

## Related Tickets & Documents

- Related Issue #63
- Closes #63
