### PR TITLE
refactor: improve secret reuse clarity (internal naming only)

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -156,26 +156,21 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 	if d.config.EnableRotation && d.provider.SupportsRotation() {
 		d.trackSecret(req, value)
 	}
-    // Determine if secret should be reusable
+    // Determine whether the caller should request a freshly issued secret.
 	createSecret := d.shouldCreateSecret(req)
 
 	log.Printf("Successfully returning secret value")
 
 	return secrets.Response{
 		Value:      value,
-		DoNotReuse: createSecret, // keep API contract intact
+		// Docker's plugin API uses DoNotReuse. We map from the clearer
+		// local "create secret" decision to preserve wire compatibility.
+		DoNotReuse: createSecret, 
 	}
 }
 
-// shouldCreateSecret decides if we need to create a new secret.
-//
-// A new secret is created if:
-//  1. The "vault_reuse" label explicitly disables reuse.
-//  2. The secret name suggests it represents a dynamic value
-//     such as a certificate or token.
-//
-// Dynamic secrets may change or expire, so generating a fresh value
-// ensures we return correct and up-to-date data.
+// shouldCreateSecret determines whether a new secret should be issued
+// for this request instead of reusing a previously returned value.
 func (d *SecretsDriver) shouldCreateSecret(req secrets.Request) bool {
 	// Check for explicit label
 	if reuse, exists := req.SecretLabels["vault_reuse"]; exists {

--- a/driver.go
+++ b/driver.go
@@ -124,7 +124,7 @@ func NewDriver() (*SecretsDriver, error) {
 	return driver, nil
 }
 
-// Get implements the secrets.Driver interface
+// Get method implements the secrets.Driver interface
 func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 	log.Printf("Received secret request for: %s using provider: %s",
 		req.SecretName, d.provider.GetProviderName())
@@ -140,7 +140,7 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Fetch secret from provider
+	// Get secret from the provider
 	value, err := d.provider.GetSecret(ctx, req)
 	if err != nil {
 		log.Printf("Error getting secret from provider: %v", err)
@@ -152,14 +152,11 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 	log.Printf("Successfully retrieved secret from %s provider",
 		d.provider.GetProviderName())
 
-	// If rotation is enabled and supported by the provider,
-	// register this secret for monitoring and future rotation.
+	// Track this secret for monitoring if rotation is enabled
 	if d.config.EnableRotation && d.provider.SupportsRotation() {
 		d.trackSecret(req, value)
 	}
-
-	// Determine whether to create a new secret
-	// or reuse the existing one.
+    // Determine if secret should be reusable
 	createSecret := d.shouldCreateSecret(req)
 
 	log.Printf("Successfully returning secret value")

--- a/driver.go
+++ b/driver.go
@@ -122,10 +122,12 @@ func NewDriver() (*SecretsDriver, error) {
 	return driver, nil
 }
 
-// Get method implements the secrets.Driver interface
+// Get implements the secrets.Driver interface
 func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
-	log.Printf("Received secret request for: %s using provider: %s", req.SecretName, d.provider.GetProviderName())
+	log.Printf("Received secret request for: %s using provider: %s",
+		req.SecretName, d.provider.GetProviderName())
 
+	// Secret name is required
 	if req.SecretName == "" {
 		return secrets.Response{
 			Err: "secret name is required",
@@ -136,7 +138,7 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Get secret from the provider
+	// Fetch secret from provider
 	value, err := d.provider.GetSecret(ctx, req)
 	if err != nil {
 		log.Printf("Error getting secret from provider: %v", err)
@@ -145,31 +147,42 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 		}
 	}
 
-	log.Printf("Successfully retrieved secret from %s provider", d.provider.GetProviderName())
+	log.Printf("Successfully retrieved secret from %s provider",
+		d.provider.GetProviderName())
 
-	// Track this secret for monitoring if rotation is enabled
+	// If rotation is enabled and supported by the provider,
+	// register this secret for monitoring and future rotation.
 	if d.config.EnableRotation && d.provider.SupportsRotation() {
 		d.trackSecret(req, value)
 	}
 
-	// Determine if secret should be reusable
-	doNotReuse := d.shouldNotReuse(req)
+	// Determine whether to create a new secret
+	// or reuse the existing one.
+	createSecret := d.shouldCreateSecret(req)
 
 	log.Printf("Successfully returning secret value")
+
 	return secrets.Response{
 		Value:      value,
-		DoNotReuse: doNotReuse,
+		DoNotReuse: createSecret, // keep API contract intact
 	}
 }
 
-// shouldNotReuse determines if the secret should not be reused
-func (d *SecretsDriver) shouldNotReuse(req secrets.Request) bool {
+// shouldCreateSecret decides if we need to create a new secret.
+//
+// A new secret is created if:
+//  1. The "vault_reuse" label explicitly disables reuse.
+//  2. The secret name suggests it represents a dynamic value
+//     such as a certificate or token.
+//
+// Dynamic secrets may change or expire, so generating a fresh value
+// ensures we return correct and up-to-date data.
+func (d *SecretsDriver) shouldCreateSecret(req secrets.Request) bool {
 	// Check for explicit label
 	if reuse, exists := req.SecretLabels["vault_reuse"]; exists {
 		return strings.ToLower(reuse) == "false"
 	}
 
-	// Don't reuse dynamic secrets or certificates
 	if strings.Contains(req.SecretName, "cert") ||
 		strings.Contains(req.SecretName, "token") ||
 		strings.Contains(req.SecretName, "dynamic") {


### PR DESCRIPTION
# Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Mention the secrets provider
N/A

## Description

Refactors internal naming for secret reuse handling to improve clarity.
No behavioral changes. External API (`DoNotReuse`) remains unchanged.

## Related Tickets & Documents

- Closes #63