### PR TITLE
feat: aws provider - support SecretBinary values in GetSecretValue response

### DIFF
--- a/providers/aws.go
+++ b/providers/aws.go
@@ -85,13 +85,13 @@ func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byt
 // AWS may return the secret as SecretString or SecretBinary depending
 // on how the secret was stored.
 func getAWSSecretValue(result *secretsmanager.GetSecretValueOutput, secretName string) (string, error) {
-	if result.SecretString != nil {
-		return *result.SecretString, nil
-	}
+	if result.SecretString != nil && *result.SecretString != "" {
+        return *result.SecretString, nil
+    }
 
-	if result.SecretBinary != nil {
-		return string(result.SecretBinary), nil
-	}
+	if len(result.SecretBinary) > 0 {
+        return string(result.SecretBinary), nil
+    }
 
 	return "", fmt.Errorf("secret %s has no value", secretName)
 }

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -48,13 +48,13 @@ func (a *AWSProvider) Initialize(config map[string]string) error {
 	log.Printf("Successfully initialized AWS Secrets Manager provider for region: %s", a.config.Region)
 	return nil
 }
-
+// GetSecret retrieves a secret value from AWS Secrets Manager
 func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byte, error) {
 	// Build the secret name based on the request
 	secretName := a.buildSecretName(req)
 	log.Printf("Reading secret from AWS Secrets Manager: %s", secretName)
 
-	// Prepare the AWS Secrets Manager request
+	// Get secret value from AWS Secrets Manager
 	input := &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(secretName),
 	}

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -49,33 +49,51 @@ func (a *AWSProvider) Initialize(config map[string]string) error {
 	return nil
 }
 
-// GetSecret retrieves a secret value from AWS Secrets Manager
 func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byte, error) {
+	// Build the secret name based on the request
 	secretName := a.buildSecretName(req)
 	log.Printf("Reading secret from AWS Secrets Manager: %s", secretName)
 
-	// Get secret value from AWS Secrets Manager
+	// Prepare the AWS Secrets Manager request
 	input := &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(secretName),
 	}
 
+	// Fetch the secret value from AWS
 	result, err := a.client.GetSecretValue(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret from AWS Secrets Manager: %v", err)
 	}
 
-	if result.SecretString == nil {
-		return nil, fmt.Errorf("secret %s has no string value", secretName)
+	// Handle both SecretString and SecretBinary returned by AWS
+	raw, err := getAWSSecretValue(result, secretName)
+	if err != nil {
+		return nil, err
 	}
 
-	// Extract the secret value
-	value, err := a.extractSecretValue(*result.SecretString, req)
+	// Extract the requested value (handles JSON/key based secrets)
+	value, err := a.extractSecretValue(raw, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract secret value: %v", err)
 	}
 
 	log.Printf("Successfully retrieved secret from AWS Secrets Manager")
 	return value, nil
+}
+
+// getAWSSecretValue extracts the raw secret value from AWS response.
+// AWS may return the secret as SecretString or SecretBinary depending
+// on how the secret was stored.
+func getAWSSecretValue(result *secretsmanager.GetSecretValueOutput, secretName string) (string, error) {
+	if result.SecretString != nil {
+		return *result.SecretString, nil
+	}
+
+	if result.SecretBinary != nil {
+		return string(result.SecretBinary), nil
+	}
+
+	return "", fmt.Errorf("secret %s has no value", secretName)
 }
 
 // SupportsRotation indicates that AWS Secrets Manager supports secret rotation monitoring

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+    "encoding/base64"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -97,9 +98,12 @@ func getAWSSecretValue(result *secretsmanager.GetSecretValueOutput, secretName s
     }
 
 	if len(result.SecretBinary) > 0 {
-        return string(result.SecretBinary), nil
+    decoded, err := base64.StdEncoding.DecodeString(string(result.SecretBinary))
+    if err != nil {
+        return "", fmt.Errorf("failed to decode binary secret %s: %v", secretName, err)
     }
-
+    return string(decoded), nil
+}
 	return "", fmt.Errorf("secret %s has no value", secretName)
 }
 

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -93,18 +93,19 @@ func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byt
 // AWS may return the secret as SecretString or SecretBinary depending
 // on how the secret was stored.
 func getAWSSecretValue(result *secretsmanager.GetSecretValueOutput, secretName string) (string, error) {
-	if result.SecretString != nil && *result.SecretString != "" {
+    if len(result.SecretBinary) > 0 {
+        decoded, err := base64.StdEncoding.DecodeString(string(result.SecretBinary))
+        if err != nil {
+            return "", fmt.Errorf("failed to decode binary secret %s: %v", secretName, err)
+        }
+        return string(decoded), nil
+    }
+
+    if result.SecretString != nil && *result.SecretString != "" {
         return *result.SecretString, nil
     }
 
-	if len(result.SecretBinary) > 0 {
-    decoded, err := base64.StdEncoding.DecodeString(string(result.SecretBinary))
-    if err != nil {
-        return "", fmt.Errorf("failed to decode binary secret %s: %v", secretName, err)
-    }
-    return string(decoded), nil
-}
-	return "", fmt.Errorf("secret %s has no value", secretName)
+    return "", fmt.Errorf("secret %s has no value", secretName)
 }
 
 // SupportsRotation indicates that AWS Secrets Manager supports secret rotation monitoring

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-    "encoding/base64"
+	"encoding/base64"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -56,6 +56,7 @@ func (a *AWSProvider) Initialize(config map[string]string) error {
 	log.Printf("Successfully initialized AWS Secrets Manager provider for region: %s", a.config.Region)
 	return nil
 }
+
 // GetSecret retrieves a secret value from AWS Secrets Manager
 func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byte, error) {
 	// Build the secret name based on the request
@@ -93,19 +94,19 @@ func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byt
 // AWS may return the secret as SecretString or SecretBinary depending
 // on how the secret was stored.
 func getAWSSecretValue(result *secretsmanager.GetSecretValueOutput, secretName string) (string, error) {
-    if len(result.SecretBinary) > 0 {
-        decoded, err := base64.StdEncoding.DecodeString(string(result.SecretBinary))
-        if err != nil {
-            return "", fmt.Errorf("failed to decode binary secret %s: %v", secretName, err)
-        }
-        return string(decoded), nil
-    }
+	if len(result.SecretBinary) > 0 {
+		decoded, err := base64.StdEncoding.DecodeString(string(result.SecretBinary))
+		if err != nil {
+			return "", fmt.Errorf("failed to decode binary secret %s: %v", secretName, err)
+		}
+		return string(decoded), nil
+	}
 
-    if result.SecretString != nil && *result.SecretString != "" {
-        return *result.SecretString, nil
-    }
+	if result.SecretString != nil && *result.SecretString != "" {
+		return *result.SecretString, nil
+	}
 
-    return "", fmt.Errorf("secret %s has no value", secretName)
+	return "", fmt.Errorf("secret %s has no value", secretName)
 }
 
 // SupportsRotation indicates that AWS Secrets Manager supports secret rotation monitoring
@@ -125,12 +126,14 @@ func (a *AWSProvider) CheckSecretChanged(ctx context.Context, secretInfo *Secret
 		return false, fmt.Errorf("error reading secret from AWS Secrets Manager: %v", err)
 	}
 
-	if result.SecretString == nil {
-		return false, fmt.Errorf("secret %s has no string value", secretInfo.SecretPath)
+	// Handle both SecretString and SecretBinary returned by AWS
+	raw, err := getAWSSecretValue(result, secretInfo.SecretPath)
+	if err != nil {
+		return false, err
 	}
 
 	// Extract current value
-	currentValue, err := a.extractSecretValueByField(*result.SecretString, secretInfo.SecretField)
+	currentValue, err := a.extractSecretValueByField(raw, secretInfo.SecretField)
 	if err != nil {
 		return false, fmt.Errorf("failed to extract secret field %s: %v", secretInfo.SecretField, err)
 	}
@@ -209,12 +212,10 @@ func (a *AWSProvider) extractSecretValue(secretString string, req secrets.Reques
 	if err := json.Unmarshal([]byte(secretString), &data); err == nil {
 		// Default field names to try
 		for _, field := range []string{"value", "password", "secret", "data"} {
-			// Try to find a value using default field names
 			if value, ok := data[field]; ok {
 				return []byte(fmt.Sprintf("%v", value)), nil
 			}
 		}
-		// If no specific field found, return the first string value
 		for _, value := range data {
 			if strValue, ok := value.(string); ok {
 				return []byte(strValue), nil
@@ -235,7 +236,6 @@ func (a *AWSProvider) extractSecretValueByField(secretString, field string) ([]b
 		if value, ok := data[field]; ok {
 			return []byte(fmt.Sprintf("%v", value)), nil
 		}
-		// Improved error message: show available keys
 		keys := make([]string, 0, len(data))
 		for k := range data {
 			keys = append(keys, k)
@@ -243,11 +243,9 @@ func (a *AWSProvider) extractSecretValueByField(secretString, field string) ([]b
 		return nil, fmt.Errorf("field %s not found in secret; available fields: %v", field, keys)
 	}
 
-	// If not JSON and field is requested, return error
 	if field != "value" {
 		return nil, fmt.Errorf("field %s not found in non-JSON secret", field)
 	}
 
-	// If field is "value" and not JSON, return the raw string
 	return []byte(secretString), nil
 }

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -3,9 +3,9 @@ package providers
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"encoding/base64"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -25,7 +25,7 @@ type AWSProvider struct {
 type AWSConfig struct {
 	Region      string
 	AccessKey   string // #nosec G117
-	SecretKey   string
+	SecretKey   string // #nosec G117
 	Profile     string
 	EndpointURL string
 }

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -56,33 +56,51 @@ func (a *AWSProvider) Initialize(config map[string]string) error {
 	return nil
 }
 
-// GetSecret retrieves a secret value from AWS Secrets Manager
 func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byte, error) {
+	// Build the secret name based on the request
 	secretName := a.buildSecretName(req)
 	log.Printf("Reading secret from AWS Secrets Manager: %s", secretName)
 
-	// Get secret value from AWS Secrets Manager
+	// Prepare the AWS Secrets Manager request
 	input := &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(secretName),
 	}
 
+	// Fetch the secret value from AWS
 	result, err := a.client.GetSecretValue(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret from AWS Secrets Manager: %v", err)
 	}
 
-	if result.SecretString == nil {
-		return nil, fmt.Errorf("secret %s has no string value", secretName)
+	// Handle both SecretString and SecretBinary returned by AWS
+	raw, err := getAWSSecretValue(result, secretName)
+	if err != nil {
+		return nil, err
 	}
 
-	// Extract the secret value
-	value, err := a.extractSecretValue(*result.SecretString, req)
+	// Extract the requested value (handles JSON/key based secrets)
+	value, err := a.extractSecretValue(raw, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract secret value: %v", err)
 	}
 
 	log.Printf("Successfully retrieved secret from AWS Secrets Manager")
 	return value, nil
+}
+
+// getAWSSecretValue extracts the raw secret value from AWS response.
+// AWS may return the secret as SecretString or SecretBinary depending
+// on how the secret was stored.
+func getAWSSecretValue(result *secretsmanager.GetSecretValueOutput, secretName string) (string, error) {
+	if result.SecretString != nil {
+		return *result.SecretString, nil
+	}
+
+	if result.SecretBinary != nil {
+		return string(result.SecretBinary), nil
+	}
+
+	return "", fmt.Errorf("secret %s has no value", secretName)
 }
 
 // SupportsRotation indicates that AWS Secrets Manager supports secret rotation monitoring

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -55,13 +55,13 @@ func (a *AWSProvider) Initialize(config map[string]string) error {
 	log.Printf("Successfully initialized AWS Secrets Manager provider for region: %s", a.config.Region)
 	return nil
 }
-
+// GetSecret retrieves a secret value from AWS Secrets Manager
 func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byte, error) {
 	// Build the secret name based on the request
 	secretName := a.buildSecretName(req)
 	log.Printf("Reading secret from AWS Secrets Manager: %s", secretName)
 
-	// Prepare the AWS Secrets Manager request
+	// Get secret value from AWS Secrets Manager
 	input := &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(secretName),
 	}

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -92,13 +92,13 @@ func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byt
 // AWS may return the secret as SecretString or SecretBinary depending
 // on how the secret was stored.
 func getAWSSecretValue(result *secretsmanager.GetSecretValueOutput, secretName string) (string, error) {
-	if result.SecretString != nil {
-		return *result.SecretString, nil
-	}
+	if result.SecretString != nil && *result.SecretString != "" {
+        return *result.SecretString, nil
+    }
 
-	if result.SecretBinary != nil {
-		return string(result.SecretBinary), nil
-	}
+	if len(result.SecretBinary) > 0 {
+        return string(result.SecretBinary), nil
+    }
 
 	return "", fmt.Errorf("secret %s has no value", secretName)
 }

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -127,16 +127,14 @@ info "Verifying rotated secret value..."
 verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE_ROTATED}" 180
 
 
-# Rotate secret with a base64 encoded binary value
 BINARY_SECRET="awssm-smoke-binary"
-BINARY_SECRET_BASE64=$(echo -n "${BINARY_SECRET}" | base64)
 
-info "Rotating secret with base64 encoded binary value..."
-awslocal_cmd secretsmanager put-secret-value \
-    --region "${AWS_REGION}" \
-    --secret-id "${SECRET_PATH}" \
-    --secret-binary "${BINARY_SECRET_BASE64}"
+echo -n "${BINARY_SECRET}" > binary_secret
 
+aws secretsmanager put-secret-value \
+  --region "${AWS_REGION}" \
+  --secret-id "${SECRET_PATH}" \
+  --secret-binary fileb://binary_secret
 sleep 30
 
 log_stack "${STACK_NAME}" "app"

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -131,11 +131,12 @@ BINARY_SECRET="awssm-smoke-binary"
 
 echo -n "${BINARY_SECRET}" > binary_secret
 
-aws secretsmanager put-secret-value \
+awslocal_cmd secretsmanager put-secret-value \
   --region "${AWS_REGION}" \
   --secret-id "${SECRET_PATH}" \
-  --secret-binary fileb://binary_secret
-sleep 30
+  --secret-binary fileb://binary_secret \
+  --version-stages AWSCURRENT
+
 
 log_stack "${STACK_NAME}" "app"
 

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -114,9 +114,10 @@ awslocal_cmd secretsmanager put-secret-value \
     --region "${AWS_REGION}" \
     --secret-id "${SECRET_PATH}" \
     --secret-string "{\"${SECRET_FIELD}\":\"${SECRET_VALUE_ROTATED}\"}"
+
 success "Secret rotated to: ${SECRET_VALUE_ROTATED}"
 
-info "Waiting for plugin rotation interval (15s)..."
+info "Waiting for plugin rotation interval..."
 sleep 30
 
 info "Logging service output after rotation..."
@@ -125,4 +126,22 @@ log_stack "${STACK_NAME}" "app"
 info "Verifying rotated secret value..."
 verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE_ROTATED}" 180
 
+
+# Rotate secret with a base64 encoded binary value
+BINARY_SECRET="awssm-smoke-binary"
+BINARY_SECRET_BASE64=$(echo -n "${BINARY_SECRET}" | base64)
+
+info "Rotating secret with base64 encoded binary value..."
+awslocal_cmd secretsmanager put-secret-value \
+    --region "${AWS_REGION}" \
+    --secret-id "${SECRET_PATH}" \
+    --secret-binary "${BINARY_SECRET_BASE64}"
+
+sleep 30
+
+log_stack "${STACK_NAME}" "app"
+
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${BINARY_SECRET}" 180
+
 success "AWS Secrets Manager smoke test PASSED"
+

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -133,11 +133,12 @@ BINARY_SECRET="awssm-smoke-binary"
 
 echo -n "${BINARY_SECRET}" > binary_secret
 
-aws secretsmanager put-secret-value \
+awslocal_cmd secretsmanager put-secret-value \
   --region "${AWS_REGION}" \
   --secret-id "${SECRET_PATH}" \
-  --secret-binary fileb://binary_secret
-sleep 30
+  --secret-binary fileb://binary_secret \
+  --version-stages AWSCURRENT
+
 
 log_stack "${STACK_NAME}" "app"
 

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -115,9 +115,10 @@ awslocal_cmd secretsmanager put-secret-value \
     --region "${AWS_REGION}" \
     --secret-id "${SECRET_PATH}" \
     --secret-string "{\"${SECRET_FIELD}\":\"${SECRET_VALUE_ROTATED}\"}"
+
 success "Secret rotated to: ${SECRET_VALUE_ROTATED}"
 
-info "Waiting for plugin rotation interval (15s)..."
+info "Waiting for plugin rotation interval..."
 sleep 30
 assert_no_sensitive_rotation_metadata_logs
 
@@ -127,4 +128,22 @@ log_stack "${STACK_NAME}" "app"
 info "Verifying rotated secret value..."
 verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE_ROTATED}" 180
 
+
+# Rotate secret with a base64 encoded binary value
+BINARY_SECRET="awssm-smoke-binary"
+BINARY_SECRET_BASE64=$(echo -n "${BINARY_SECRET}" | base64)
+
+info "Rotating secret with base64 encoded binary value..."
+awslocal_cmd secretsmanager put-secret-value \
+    --region "${AWS_REGION}" \
+    --secret-id "${SECRET_PATH}" \
+    --secret-binary "${BINARY_SECRET_BASE64}"
+
+sleep 30
+
+log_stack "${STACK_NAME}" "app"
+
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${BINARY_SECRET}" 180
+
 success "AWS Secrets Manager smoke test PASSED"
+

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -129,16 +129,14 @@ info "Verifying rotated secret value..."
 verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE_ROTATED}" 180
 
 
-# Rotate secret with a base64 encoded binary value
 BINARY_SECRET="awssm-smoke-binary"
-BINARY_SECRET_BASE64=$(echo -n "${BINARY_SECRET}" | base64)
 
-info "Rotating secret with base64 encoded binary value..."
-awslocal_cmd secretsmanager put-secret-value \
-    --region "${AWS_REGION}" \
-    --secret-id "${SECRET_PATH}" \
-    --secret-binary "${BINARY_SECRET_BASE64}"
+echo -n "${BINARY_SECRET}" > binary_secret
 
+aws secretsmanager put-secret-value \
+  --region "${AWS_REGION}" \
+  --secret-id "${SECRET_PATH}" \
+  --secret-binary fileb://binary_secret
 sleep 30
 
 log_stack "${STACK_NAME}" "app"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Mention the secrets provider 

AWS Secrets Manager

## Description

Adds support for both `SecretString` and `SecretBinary` returned by the AWS Secrets Manager `GetSecretValue` API.  
Previously only `SecretString` was handled which caused failures when the secret was stored as binary.

A small helper function is introduced to cleanly extract the raw secret value from the AWS response.

Tested both SecretString and SecretBinary cases using localstack.
Both formats are returned correctly and handled by the AWS provider.

```bash
$ aws --endpoint-url=http://localhost:4566 secretsmanager get-secret-value --secret-id test-string-secret
SecretString: hello-from-secretstring

$ aws --endpoint-url=http://localhost:4566 secretsmanager get-secret-value --secret-id test-binary-secret
SecretBinary: aGVsbG8tZnJvbS1iaW5hcnkK
```
## Related Tickets & Documents

- Related Issue #74
- Closes #74