### PR TITLE
Fix- openbao as provider is not working bug.

### DIFF
--- a/config.json
+++ b/config.json
@@ -88,11 +88,6 @@
       "settable": ["value"]
     },
     {
-      "name": "OPENBAO_AUTH_METHOD",
-      "description": "OpenBao authentication method",
-      "settable": ["value"]
-    },
-    {
       "name": "OPENBAO_TOKEN",
       "description": "OpenBao authentication token",
       "settable": ["value"]
@@ -100,6 +95,11 @@
     {
       "name": "OPENBAO_MOUNT_PATH",
       "description": "OpenBao mount path",
+      "settable": ["value"]
+    },
+    {
+      "name": "OPENBAO_KV_VERSION",
+      "description": "OpenBao KV engine version (1 or 2)",
       "settable": ["value"]
     },
     {

--- a/docs/multi-provider.md
+++ b/docs/multi-provider.md
@@ -100,6 +100,7 @@ docker plugin set swarm-external-secrets:latest \
 | `OPENBAO_ADDR` | OpenBao server address | `http://localhost:8200` |
 | `OPENBAO_TOKEN` | OpenBao token for authentication | — |
 | `OPENBAO_MOUNT_PATH` | Mount path for KV engine | `secret` |
+| `OPENBAO_KV_VERSION` | KV engine version (`1` or `2`) | `2` |
 | `OPENBAO_AUTH_METHOD` | Authentication method (`token`, `approle`) | `token` |
 | `OPENBAO_ROLE_ID` | Role ID for AppRole authentication | — |
 | `OPENBAO_SECRET_ID` | Secret ID for AppRole authentication | — |

--- a/driver.go
+++ b/driver.go
@@ -357,7 +357,7 @@ func (d *SecretsDriver) rotateSecret(secretInfo *providers.SecretInfo) error {
 		req.SecretLabels["azure_secret_name"] = secretInfo.SecretPath
 	case "openbao":
 		req.SecretLabels["openbao_field"] = secretInfo.SecretField
-		req.SecretLabels["openbao_path"] = strings.TrimPrefix(secretInfo.SecretPath, "secret/data/")
+		req.SecretLabels["openbao_path"] = stripProviderMountPrefix(secretInfo.SecretPath)
 	}
 
 	// Get the new secret value from the provider
@@ -584,16 +584,49 @@ func (d *SecretsDriver) buildVaultSecretPath(req secrets.Request) string {
 }
 
 func (d *SecretsDriver) buildOpenBaoSecretPath(req secrets.Request) string {
-	// Use custom path from labels if provided
-	if customPath, exists := req.SecretLabels["openbao_path"]; exists {
-		return fmt.Sprintf("secret/data/%s", customPath)
+	mountPath := strings.Trim(d.config.Settings["OPENBAO_MOUNT_PATH"], "/")
+	if mountPath == "" {
+		mountPath = "secret"
+	}
+	kvVersion := d.config.Settings["OPENBAO_KV_VERSION"]
+	if kvVersion == "" {
+		kvVersion = "2"
 	}
 
-	// Default path structure for KV v2
-	if req.ServiceName != "" {
-		return fmt.Sprintf("secret/data/%s/%s", req.ServiceName, req.SecretName)
+	// Use custom path from labels if provided
+	if customPath, exists := req.SecretLabels["openbao_path"]; exists {
+		return formatOpenBaoPath(mountPath, kvVersion, customPath)
 	}
-	return fmt.Sprintf("secret/data/%s", req.SecretName)
+
+	// Default path structure
+	if req.ServiceName != "" {
+		return formatOpenBaoPath(mountPath, kvVersion, fmt.Sprintf("%s/%s", req.ServiceName, req.SecretName))
+	}
+	return formatOpenBaoPath(mountPath, kvVersion, req.SecretName)
+}
+
+func formatOpenBaoPath(mountPath, kvVersion, rawPath string) string {
+	path := strings.Trim(strings.TrimSpace(rawPath), "/")
+	if strings.HasPrefix(path, mountPath+"/") {
+		path = strings.TrimPrefix(path, mountPath+"/")
+	}
+	path = strings.TrimPrefix(path, "data/")
+
+	if strings.TrimSpace(kvVersion) == "1" {
+		return fmt.Sprintf("%s/%s", mountPath, path)
+	}
+	return fmt.Sprintf("%s/data/%s", mountPath, path)
+}
+
+func stripProviderMountPrefix(secretPath string) string {
+	path := strings.Trim(strings.TrimSpace(secretPath), "/")
+	if idx := strings.Index(path, "/data/"); idx >= 0 {
+		return path[idx+len("/data/"):]
+	}
+	if idx := strings.Index(path, "/"); idx >= 0 {
+		return path[idx+1:]
+	}
+	return path
 }
 
 func (d *SecretsDriver) buildAWSSecretName(req secrets.Request) string {

--- a/providers/factory.go
+++ b/providers/factory.go
@@ -67,7 +67,7 @@ func GetProviderInfo(providerType string) (map[string]string, error) {
 		info["name"] = "OpenBao"
 		info["description"] = "OpenBao secrets engine (Vault-compatible)"
 		info["auth_methods"] = "token, approle"
-		info["env_vars"] = "OPENBAO_ADDR, OPENBAO_TOKEN, OPENBAO_MOUNT_PATH, OPENBAO_AUTH_METHOD, OPENBAO_ROLE_ID, OPENBAO_SECRET_ID"
+		info["env_vars"] = "OPENBAO_ADDR, OPENBAO_TOKEN, OPENBAO_MOUNT_PATH, OPENBAO_KV_VERSION, OPENBAO_AUTH_METHOD, OPENBAO_ROLE_ID, OPENBAO_SECRET_ID"
 
 	default:
 		return nil, fmt.Errorf("unsupported provider type: %s", providerType)

--- a/providers/openbao.go
+++ b/providers/openbao.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"strings"
 
 	"github.com/docker/go-plugins-helpers/secrets"
 	"github.com/openbao/openbao/api/v2"
@@ -22,6 +23,7 @@ type OpenBaoConfig struct {
 	Address    string
 	Token      string
 	MountPath  string
+	KVVersion  string
 	RoleID     string
 	SecretID   string
 	AuthMethod string
@@ -36,6 +38,7 @@ func (o *OpenBaoProvider) Initialize(config map[string]string) error {
 		Address:    getConfigOrDefault(config, "OPENBAO_ADDR", "http://localhost:8200"),
 		Token:      config["OPENBAO_TOKEN"],
 		MountPath:  getConfigOrDefault(config, "OPENBAO_MOUNT_PATH", "secret"),
+		KVVersion:  getConfigOrDefault(config, "OPENBAO_KV_VERSION", "2"),
 		RoleID:     config["OPENBAO_ROLE_ID"],
 		SecretID:   config["OPENBAO_SECRET_ID"],
 		AuthMethod: getConfigOrDefault(config, "OPENBAO_AUTH_METHOD", "token"),
@@ -119,11 +122,9 @@ func (o *OpenBaoProvider) CheckSecretChanged(ctx context.Context, secretInfo *Se
 	}
 
 	// Extract current value
-	var data map[string]interface{}
-	if secretData, ok := secret.Data["data"]; ok {
-		data = secretData.(map[string]interface{})
-	} else {
-		data = secret.Data
+	data, err := extractOpenBaoData(secret)
+	if err != nil {
+		return false, err
 	}
 
 	var currentValue []byte
@@ -152,7 +153,8 @@ func (o *OpenBaoProvider) Close() error {
 
 // authenticate handles various OpenBao authentication methods
 func (o *OpenBaoProvider) authenticate() error {
-	switch o.config.AuthMethod {
+	authMethod := strings.ToLower(strings.TrimSpace(o.config.AuthMethod))
+	switch authMethod {
 	case "token":
 		if o.config.Token == "" {
 			return fmt.Errorf("OPENBAO_TOKEN is required for token authentication")
@@ -189,38 +191,42 @@ func (o *OpenBaoProvider) authenticate() error {
 
 // buildSecretPath constructs the OpenBao secret path based on request labels and service information
 func (o *OpenBaoProvider) buildSecretPath(req secrets.Request) string {
+	mountPath := strings.Trim(strings.TrimSpace(o.config.MountPath), "/")
+	if mountPath == "" {
+		mountPath = "secret"
+	}
+
 	// Use custom path from labels if provided
 	if customPath, exists := req.SecretLabels["openbao_path"]; exists {
-		// For KV v2, ensure we have the /data/ prefix
-		if o.config.MountPath == "secret" {
-			return fmt.Sprintf("%s/data/%s", o.config.MountPath, customPath)
-		}
-		return fmt.Sprintf("%s/%s", o.config.MountPath, customPath)
+		return o.formatSecretPath(mountPath, customPath)
 	}
 
-	// Default path structure for KV v2
-	if o.config.MountPath == "secret" {
-		if req.ServiceName != "" {
-			return fmt.Sprintf("%s/data/%s/%s", o.config.MountPath, req.ServiceName, req.SecretName)
-		}
-		return fmt.Sprintf("%s/data/%s", o.config.MountPath, req.SecretName)
-	}
-
-	// For other mount paths
+	// Default path structure if labels are not provided
+	basePath := req.SecretName
 	if req.ServiceName != "" {
-		return fmt.Sprintf("%s/%s/%s", o.config.MountPath, req.ServiceName, req.SecretName)
+		basePath = fmt.Sprintf("%s/%s", req.ServiceName, req.SecretName)
 	}
-	return fmt.Sprintf("%s/%s", o.config.MountPath, req.SecretName)
+	return o.formatSecretPath(mountPath, basePath)
+}
+
+func (o *OpenBaoProvider) formatSecretPath(mountPath, rawPath string) string {
+	path := strings.Trim(strings.TrimSpace(rawPath), "/")
+	if strings.HasPrefix(path, mountPath+"/") {
+		path = strings.TrimPrefix(path, mountPath+"/")
+	}
+	path = strings.TrimPrefix(path, "data/")
+
+	if strings.TrimSpace(o.config.KVVersion) == "1" {
+		return fmt.Sprintf("%s/%s", mountPath, path)
+	}
+	return fmt.Sprintf("%s/data/%s", mountPath, path)
 }
 
 // extractSecretValue extracts the appropriate value from the OpenBao response
 func (o *OpenBaoProvider) extractSecretValue(secret *api.Secret, req secrets.Request) ([]byte, error) {
-	// For KV v2, data is nested under "data"
-	var data map[string]interface{}
-	if secretData, ok := secret.Data["data"]; ok {
-		data = secretData.(map[string]interface{})
-	} else {
-		data = secret.Data
+	data, err := extractOpenBaoData(secret)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check for specific field in labels
@@ -249,4 +255,19 @@ func (o *OpenBaoProvider) extractSecretValue(secret *api.Secret, req secrets.Req
 	}
 
 	return nil, fmt.Errorf("no suitable secret value found")
+}
+
+func extractOpenBaoData(secret *api.Secret) (map[string]interface{}, error) {
+	if secret == nil {
+		return nil, fmt.Errorf("secret is nil")
+	}
+
+	if secretData, ok := secret.Data["data"]; ok {
+		if nested, ok := secretData.(map[string]interface{}); ok {
+			return nested, nil
+		}
+		return nil, fmt.Errorf("unexpected OpenBao secret data format")
+	}
+
+	return secret.Data, nil
 }


### PR DESCRIPTION
Updated providers/openbao.go:
Added OPENBAO_KV_VERSION support (default 2).

Normalized auth method with strings.ToLower(strings.TrimSpace(...)). Reworked OpenBao secret path formatting to:
work with any mount path,

avoid duplicate mount/data prefixes,

support KV v1 (OPENBAO_KV_VERSION=1) and KV v2 (2). Updated driver.go:
buildOpenBaoSecretPath() now uses OPENBAO_MOUNT_PATH + OPENBAO_KV_VERSION instead of hardcoded secret/data/.... Rotation now strips provider mount prefix generically (not just secret/data/...) so OpenBao rotation continues 
to work on custom mounts. 

Updated config/docs metadata:
Added OPENBAO_KV_VERSION to config.json (settable). Added OPENBAO_KV_VERSION in providers/factory.go provider env info. Documented it in docs/multi-provider.md.
Removed duplicate OPENBAO_AUTH_METHOD entry in config.json.

Updated both:
GetSecret extraction path (extractSecretValue)
rotation change detection (CheckSecretChanged)
to use the safe helper and return a clear error instead of panicking.

