### PR TITLE
[fixed bug]:AWS provider does not handle SecretBinary values

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -344,8 +344,7 @@ func (d *SecretsDriver) rotateSecret(secretInfo *providers.SecretInfo) error {
 	switch secretInfo.Provider {
 	case "vault":
 		req.SecretLabels["vault_field"] = secretInfo.SecretField
-		// Extract the specific path part from the full path
-		req.SecretLabels["vault_path"] = strings.TrimPrefix(secretInfo.SecretPath, "secret/data/")
+		req.SecretLabels["vault_path"] = stripProviderMountPrefix(secretInfo.SecretPath)
 	case "aws":
 		req.SecretLabels["aws_field"] = secretInfo.SecretField
 		req.SecretLabels["aws_secret_name"] = secretInfo.SecretPath
@@ -357,7 +356,7 @@ func (d *SecretsDriver) rotateSecret(secretInfo *providers.SecretInfo) error {
 		req.SecretLabels["azure_secret_name"] = secretInfo.SecretPath
 	case "openbao":
 		req.SecretLabels["openbao_field"] = secretInfo.SecretField
-		req.SecretLabels["openbao_path"] = strings.TrimPrefix(secretInfo.SecretPath, "secret/data/")
+		req.SecretLabels["openbao_path"] = stripProviderMountPrefix(secretInfo.SecretPath)
 	}
 
 	// Get the new secret value from the provider
@@ -571,29 +570,70 @@ func (d *SecretsDriver) Stop() error {
 // Helper methods for building provider-specific secret paths/names
 
 func (d *SecretsDriver) buildVaultSecretPath(req secrets.Request) string {
-	// Use custom path from labels if provided
-	if customPath, exists := req.SecretLabels["vault_path"]; exists {
-		return fmt.Sprintf("secret/data/%s", customPath)
+	mountPath := getEnvOrDefault("VAULT_MOUNT_PATH", "secret")
+	mountPath = strings.Trim(mountPath, "/")
+	if mountPath == "" {
+		mountPath = "secret"
 	}
 
-	// Default path structure for KV v2
-	if req.ServiceName != "" {
-		return fmt.Sprintf("secret/data/%s/%s", req.ServiceName, req.SecretName)
+	// Use custom path from labels if provided
+	if customPath, exists := req.SecretLabels["vault_path"]; exists {
+		if mountPath == "secret" {
+			return fmt.Sprintf("%s/data/%s", mountPath, customPath)
+		}
+		return fmt.Sprintf("%s/%s", mountPath, customPath)
 	}
-	return fmt.Sprintf("secret/data/%s", req.SecretName)
+
+	// Default path structure
+	if mountPath == "secret" {
+		if req.ServiceName != "" {
+			return fmt.Sprintf("%s/data/%s/%s", mountPath, req.ServiceName, req.SecretName)
+		}
+		return fmt.Sprintf("%s/data/%s", mountPath, req.SecretName)
+	}
+	if req.ServiceName != "" {
+		return fmt.Sprintf("%s/%s/%s", mountPath, req.ServiceName, req.SecretName)
+	}
+	return fmt.Sprintf("%s/%s", mountPath, req.SecretName)
 }
 
 func (d *SecretsDriver) buildOpenBaoSecretPath(req secrets.Request) string {
-	// Use custom path from labels if provided
-	if customPath, exists := req.SecretLabels["openbao_path"]; exists {
-		return fmt.Sprintf("secret/data/%s", customPath)
+	mountPath := getEnvOrDefault("OPENBAO_MOUNT_PATH", "secret")
+	mountPath = strings.Trim(mountPath, "/")
+	if mountPath == "" {
+		mountPath = "secret"
 	}
 
-	// Default path structure for KV v2
-	if req.ServiceName != "" {
-		return fmt.Sprintf("secret/data/%s/%s", req.ServiceName, req.SecretName)
+	// Use custom path from labels if provided
+	if customPath, exists := req.SecretLabels["openbao_path"]; exists {
+		if mountPath == "secret" {
+			return fmt.Sprintf("%s/data/%s", mountPath, customPath)
+		}
+		return fmt.Sprintf("%s/%s", mountPath, customPath)
 	}
-	return fmt.Sprintf("secret/data/%s", req.SecretName)
+
+	// Default path structure
+	if mountPath == "secret" {
+		if req.ServiceName != "" {
+			return fmt.Sprintf("%s/data/%s/%s", mountPath, req.ServiceName, req.SecretName)
+		}
+		return fmt.Sprintf("%s/data/%s", mountPath, req.SecretName)
+	}
+	if req.ServiceName != "" {
+		return fmt.Sprintf("%s/%s/%s", mountPath, req.ServiceName, req.SecretName)
+	}
+	return fmt.Sprintf("%s/%s", mountPath, req.SecretName)
+}
+
+func stripProviderMountPrefix(secretPath string) string {
+	path := strings.Trim(strings.TrimSpace(secretPath), "/")
+	if idx := strings.Index(path, "/data/"); idx >= 0 {
+		return path[idx+len("/data/"):]
+	}
+	if idx := strings.Index(path, "/"); idx >= 0 {
+		return path[idx+1:]
+	}
+	return path
 }
 
 func (d *SecretsDriver) buildAWSSecretName(req secrets.Request) string {

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -71,12 +71,13 @@ func (a *AWSProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byt
 		return nil, fmt.Errorf("failed to get secret from AWS Secrets Manager: %v", err)
 	}
 
-	if result.SecretString == nil {
-		return nil, fmt.Errorf("secret %s has no string value", secretName)
+	secretData, err := extractAWSSecretData(result, secretName)
+	if err != nil {
+		return nil, err
 	}
 
 	// Extract the secret value
-	value, err := a.extractSecretValue(*result.SecretString, req)
+	value, err := a.extractSecretValue(secretData, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract secret value: %v", err)
 	}
@@ -102,12 +103,13 @@ func (a *AWSProvider) CheckSecretChanged(ctx context.Context, secretInfo *Secret
 		return false, fmt.Errorf("error reading secret from AWS Secrets Manager: %v", err)
 	}
 
-	if result.SecretString == nil {
-		return false, fmt.Errorf("secret %s has no string value", secretInfo.SecretPath)
+	secretData, err := extractAWSSecretData(result, secretInfo.SecretPath)
+	if err != nil {
+		return false, err
 	}
 
 	// Extract current value
-	currentValue, err := a.extractSecretValueByField(*result.SecretString, secretInfo.SecretField)
+	currentValue, err := a.extractSecretValueByField(secretData, secretInfo.SecretField)
 	if err != nil {
 		return false, fmt.Errorf("failed to extract secret field %s: %v", secretInfo.SecretField, err)
 	}
@@ -174,16 +176,16 @@ func (a *AWSProvider) buildSecretName(req secrets.Request) string {
 	return req.SecretName
 }
 
-// extractSecretValue extracts the appropriate value from the AWS secret string
-func (a *AWSProvider) extractSecretValue(secretString string, req secrets.Request) ([]byte, error) {
+// extractSecretValue extracts the appropriate value from AWS secret payload bytes.
+func (a *AWSProvider) extractSecretValue(secretData []byte, req secrets.Request) ([]byte, error) {
 	// Check for specific field in labels
 	if field, exists := req.SecretLabels["aws_field"]; exists {
-		return a.extractSecretValueByField(secretString, field)
+		return a.extractSecretValueByField(secretData, field)
 	}
 
 	// Try to parse as JSON first
 	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(secretString), &data); err == nil {
+	if err := json.Unmarshal(secretData, &data); err == nil {
 		// Default field names to try
 		for _, field := range []string{"value", "password", "secret", "data"} {
 			// Try to find a value using default field names
@@ -200,15 +202,15 @@ func (a *AWSProvider) extractSecretValue(secretString string, req secrets.Reques
 		return nil, fmt.Errorf("no suitable secret value found in JSON")
 	}
 
-	// If not JSON, return the raw string
-	return []byte(secretString), nil
+	// If not JSON, return raw bytes (supports SecretBinary)
+	return secretData, nil
 }
 
-// extractSecretValueByField extracts a specific field from the secret string
-func (a *AWSProvider) extractSecretValueByField(secretString, field string) ([]byte, error) {
+// extractSecretValueByField extracts a specific field from AWS secret payload bytes.
+func (a *AWSProvider) extractSecretValueByField(secretData []byte, field string) ([]byte, error) {
 	// Try to parse as JSON first
 	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(secretString), &data); err == nil {
+	if err := json.Unmarshal(secretData, &data); err == nil {
 		if value, ok := data[field]; ok {
 			return []byte(fmt.Sprintf("%v", value)), nil
 		}
@@ -225,6 +227,16 @@ func (a *AWSProvider) extractSecretValueByField(secretString, field string) ([]b
 		return nil, fmt.Errorf("field %s not found in non-JSON secret", field)
 	}
 
-	// If field is "value" and not JSON, return the raw string
-	return []byte(secretString), nil
+	// If field is "value" and not JSON, return raw bytes (supports SecretBinary)
+	return secretData, nil
+}
+
+func extractAWSSecretData(result *secretsmanager.GetSecretValueOutput, secretName string) ([]byte, error) {
+	if result.SecretString != nil {
+		return []byte(*result.SecretString), nil
+	}
+	if result.SecretBinary != nil {
+		return result.SecretBinary, nil
+	}
+	return nil, fmt.Errorf("secret %s has neither string nor binary value", secretName)
 }

--- a/providers/openbao.go
+++ b/providers/openbao.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"strings"
 
 	"github.com/docker/go-plugins-helpers/secrets"
 	"github.com/openbao/openbao/api/v2"
@@ -119,11 +120,9 @@ func (o *OpenBaoProvider) CheckSecretChanged(ctx context.Context, secretInfo *Se
 	}
 
 	// Extract current value
-	var data map[string]interface{}
-	if secretData, ok := secret.Data["data"]; ok {
-		data = secretData.(map[string]interface{})
-	} else {
-		data = secret.Data
+	data, err := extractOpenBaoData(secret)
+	if err != nil {
+		return false, err
 	}
 
 	var currentValue []byte
@@ -152,7 +151,7 @@ func (o *OpenBaoProvider) Close() error {
 
 // authenticate handles various OpenBao authentication methods
 func (o *OpenBaoProvider) authenticate() error {
-	switch o.config.AuthMethod {
+	switch strings.ToLower(strings.TrimSpace(o.config.AuthMethod)) {
 	case "token":
 		if o.config.Token == "" {
 			return fmt.Errorf("OPENBAO_TOKEN is required for token authentication")
@@ -215,12 +214,9 @@ func (o *OpenBaoProvider) buildSecretPath(req secrets.Request) string {
 
 // extractSecretValue extracts the appropriate value from the OpenBao response
 func (o *OpenBaoProvider) extractSecretValue(secret *api.Secret, req secrets.Request) ([]byte, error) {
-	// For KV v2, data is nested under "data"
-	var data map[string]interface{}
-	if secretData, ok := secret.Data["data"]; ok {
-		data = secretData.(map[string]interface{})
-	} else {
-		data = secret.Data
+	data, err := extractOpenBaoData(secret)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check for specific field in labels
@@ -249,4 +245,17 @@ func (o *OpenBaoProvider) extractSecretValue(secret *api.Secret, req secrets.Req
 	}
 
 	return nil, fmt.Errorf("no suitable secret value found")
+}
+
+func extractOpenBaoData(secret *api.Secret) (map[string]interface{}, error) {
+	if secret == nil {
+		return nil, fmt.Errorf("secret is nil")
+	}
+	if secretData, ok := secret.Data["data"]; ok {
+		if nested, ok := secretData.(map[string]interface{}); ok {
+			return nested, nil
+		}
+		return nil, fmt.Errorf("unexpected OpenBao secret data format")
+	}
+	return secret.Data, nil
 }

--- a/providers/vault.go
+++ b/providers/vault.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/docker/go-plugins-helpers/secrets"
 	"github.com/hashicorp/vault/api"
@@ -119,11 +120,9 @@ func (v *VaultProvider) CheckSecretChanged(ctx context.Context, secretInfo *Secr
 	}
 
 	// Extract current value
-	var data map[string]interface{}
-	if secretData, ok := secret.Data["data"]; ok {
-		data = secretData.(map[string]interface{})
-	} else {
-		data = secret.Data
+	data, err := extractVaultData(secret)
+	if err != nil {
+		return false, err
 	}
 
 	var currentValue []byte
@@ -152,7 +151,7 @@ func (v *VaultProvider) Close() error {
 
 // authenticate handles various Vault authentication methods
 func (v *VaultProvider) authenticate() error {
-	switch v.config.AuthMethod {
+	switch strings.ToLower(strings.TrimSpace(v.config.AuthMethod)) {
 	case "token":
 		if v.config.Token == "" {
 			return fmt.Errorf("VAULT_TOKEN is required for token authentication")
@@ -215,12 +214,9 @@ func (v *VaultProvider) buildSecretPath(req secrets.Request) string {
 
 // extractSecretValue extracts the appropriate value from the Vault response
 func (v *VaultProvider) extractSecretValue(secret *api.Secret, req secrets.Request) ([]byte, error) {
-	// For KV v2, data is nested under "data"
-	var data map[string]interface{}
-	if secretData, ok := secret.Data["data"]; ok {
-		data = secretData.(map[string]interface{})
-	} else {
-		data = secret.Data
+	data, err := extractVaultData(secret)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check for specific field in labels
@@ -249,6 +245,19 @@ func (v *VaultProvider) extractSecretValue(secret *api.Secret, req secrets.Reque
 	}
 
 	return nil, fmt.Errorf("no suitable secret value found")
+}
+
+func extractVaultData(secret *api.Secret) (map[string]interface{}, error) {
+	if secret == nil {
+		return nil, fmt.Errorf("secret is nil")
+	}
+	if secretData, ok := secret.Data["data"]; ok {
+		if nested, ok := secretData.(map[string]interface{}); ok {
+			return nested, nil
+		}
+		return nil, fmt.Errorf("unexpected Vault secret data format")
+	}
+	return secret.Data, nil
 }
 
 // getConfigOrDefault returns config value or environment variable or default


### PR DESCRIPTION
What was wrong
providers/aws.go assumed GetSecretValue always returns SecretString. If a secret is stored as binary (SecretBinary), it returned an error and failed retrieval/rotation checks. What I changed
Added extractAWSSecretData(...) to read payload from either: SecretString (converted to bytes), or
SecretBinary (raw bytes).


Updated both call paths to use it:
GetSecret(...)
CheckSecretChanged(...)
Refactored extractors to operate on []byte instead of string: extractSecretValue(...)
extractSecretValueByField(...)


Behavior now
Binary secrets work end-to-end.
If binary payload is JSON, aws_field extraction still works. If binary payload is non-JSON:
aws_field=value returns raw bytes.
any other aws_field returns a clear error (same semantics as non-JSON string secrets).


Fixed errors
providers/vault.go
Removed panic-prone type assertions on secret payload (secret.Data["data"].(map[string]interface{})). Added safe parser extractVaultData(...) with error handling. Normalized VAULT_AUTH_METHOD handling (trim + lowercase) to avoid casing-related auth failures. 

providers/openbao.go
Removed the same panic-prone type assertions.
Added safe parser extractOpenBaoData(...).
Normalized OPENBAO_AUTH_METHOD handling (trim + lowercase).

 driver.go
Fixed rotation request label reconstruction for Vault/OpenBao: Replaced hardcoded strings.TrimPrefix(..., "secret/data/") with generic stripProviderMountPrefix(...), so non-default mount prefixes no longer break rotation. Updated buildVaultSecretPath(...) and buildOpenBaoSecretPath(...) to respect mount path env (VAULT_MOUNT_PATH, OPENBAO_MOUNT_PATH) instead of always hardcoding secret/.... 

providers/aws.go (already fixed in this pass context) 
Added SecretBinary support (not just SecretString) for both normal reads and change checks.

