### PR TITLE
fix: make Monitor.Stop() idempotent with sync.Once

### DIFF
--- a/monitoring/monitor.go
+++ b/monitoring/monitor.go
@@ -35,6 +35,7 @@ type Monitor struct {
 	listeners   []chan *Metrics
 	listenersMu sync.RWMutex
 	lastLogTime time.Time
+	stopOnce    sync.Once
 }
 
 // NewMonitor creates a new monitoring instance
@@ -58,21 +59,24 @@ func (m *Monitor) Start() {
 	log.Printf("Started system monitoring with interval: %v", m.interval)
 }
 
-// Stop stops the monitoring process
+// Stop stops the monitoring process. It is safe to call multiple times;
+// only the first call performs the actual shutdown.
 func (m *Monitor) Stop() {
-	if m.cancel != nil {
-		m.cancel()
-	}
+	m.stopOnce.Do(func() {
+		if m.cancel != nil {
+			m.cancel()
+		}
 
-	// Close all listener channels
-	m.listenersMu.Lock()
-	for _, listener := range m.listeners {
-		close(listener)
-	}
-	m.listeners = nil
-	m.listenersMu.Unlock()
+		// Close all listener channels
+		m.listenersMu.Lock()
+		for _, listener := range m.listeners {
+			close(listener)
+		}
+		m.listeners = nil
+		m.listenersMu.Unlock()
 
-	log.Printf("Stopped system monitoring")
+		log.Printf("Stopped system monitoring")
+	})
 }
 
 // GetMetrics returns a copy of current metrics


### PR DESCRIPTION
## Summary
- Wraps `Monitor.Stop()` shutdown logic in `sync.Once` to prevent double-close panic
- Adds `stopOnce sync.Once` field to the `Monitor` struct
- Calling `Stop()` multiple times (sequentially or concurrently) is now safe

## Root Cause
`Stop()` closed all listener channels directly. A second call would attempt to close already-closed channels, causing `panic: close of closed channel`.

## Test plan
- [ ] Call `Stop()` twice sequentially — no panic
- [ ] Call `Stop()` concurrently from multiple goroutines — no panic
- [ ] Verify listeners still receive metrics before `Stop()` is called

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)