### PR TITLE
docs: use global rotation env vars in docs and examples

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -91,7 +91,7 @@ ENABLE_MONITORING=true
 MONITORING_PORT=8080
 
 # Rotation monitoring interval (default: 10s)
-VAULT_ROTATION_INTERVAL=30s
+ROTATION_INTERVAL=30s
 ```
 
 ### Docker Plugin Configuration
@@ -100,7 +100,7 @@ VAULT_ROTATION_INTERVAL=30s
 docker plugin set swarm-external-secrets:latest \
     ENABLE_MONITORING=true \
     MONITORING_PORT=9090 \
-    VAULT_ROTATION_INTERVAL=1m
+    ROTATION_INTERVAL=1m
 ```
 
 ## Integration Examples

--- a/docs/rotation.md
+++ b/docs/rotation.md
@@ -23,20 +23,20 @@ The following environment variables control the rotation behavior:
 
 | Variable | Description | Default |
 |---|---|---|
-| `VAULT_ENABLE_ROTATION` | Enable/disable automatic rotation | `true` |
-| `VAULT_ROTATION_INTERVAL` | How often to check for changes | `5m` |
+| `ENABLE_ROTATION` | Enable/disable automatic rotation | `true` |
+| `ROTATION_INTERVAL` | How often to check for changes | `10s` |
 
 ### Example Configuration
 
 ```bash
 # Enable rotation with 2-minute check interval
 docker plugin set swarm-external-secrets:latest \
-    VAULT_ENABLE_ROTATION="true" \
-    VAULT_ROTATION_INTERVAL="2m"
+    ENABLE_ROTATION="true" \
+    ROTATION_INTERVAL="2m"
 
 # Disable rotation
 docker plugin set swarm-external-secrets:latest \
-    VAULT_ENABLE_ROTATION="false"
+    ENABLE_ROTATION="false"
 ```
 
 ## Usage Example
@@ -90,7 +90,7 @@ docker service logs <service-name>
 
 If rotation is not working:
 
-1. Check if rotation is enabled: `VAULT_ENABLE_ROTATION=true`
+1. Check if rotation is enabled: `ENABLE_ROTATION=true`
 2. Verify plugin has access to Docker socket
 3. Ensure plugin is running on a manager node
 4. Check plugin logs for error messages

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ docker plugin set swarm-external-secrets:latest \
        VAULT_ADDR="https://your-vault-server:8200" \
        VAULT_AUTH_METHOD="token" \
        VAULT_TOKEN="your-vault-token" \
-       VAULT_ENABLE_ROTATION="true"
+       ENABLE_ROTATION="true"
    ```
 
 3. Use in docker-compose.yml:


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change 
ex: - [x] Refactor
-->

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [x] Documentation
- [ ] CI

## Mention the secrets provider 
N/A (docs-only change, provider-agnostic rotation config)

## Description

Docs previously referenced:
- `VAULT_ENABLE_ROTATION`
- `VAULT_ROTATION_INTERVAL`

But runtime code reads global variables:
- `ENABLE_ROTATION`
- `ROTATION_INTERVAL`

Updated files:
- `readme.md`
- `docs/rotation.md`
- `docs/monitoring.md`

Also aligned the documented default rotation interval in docs to `10s` (matching code default).


## Commands & Configuration to test

```bash
# verify old names are removed from updated docs
rg -n "VAULT_ENABLE_ROTATION|VAULT_ROTATION_INTERVAL" readme.md docs/rotation.md docs/monitoring.md
```

## Screenshots & Logs
N/A (documentation-only fix)

## Related Tickets & Documents

- Related Issue #
- Closes #94 


## Was this PR authored or co-authored using generative AI tooling?
No, done manually by me