### PR TITLE
fix(rotation): remove old secret only after running tasks stop using it

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -575,34 +575,59 @@ func (d *SecretsDriver) isOldSecretUsedByRunningTasks(ctx context.Context, servi
 	}
 
 	for _, serviceID := range serviceIDs {
-		taskList, err := d.dockerClient.TaskList(ctx, swarm.TaskListOptions{
-			Filters: filtersForService(serviceID),
-		})
+		taskList, err := d.listServiceTasks(ctx, serviceID)
 		if err != nil {
-			return false, fmt.Errorf("failed to list tasks for service %s: %v", serviceID, err)
+			return false, err
 		}
 
-		for _, task := range taskList {
-			if task.DesiredState != swarm.TaskStateRunning || task.Status.State != swarm.TaskStateRunning {
-				continue
-			}
-			if task.Spec.ContainerSpec == nil {
-				continue
-			}
-
-			for _, secretRef := range task.Spec.ContainerSpec.Secrets {
-				if secretRef == nil {
-					continue
-				}
-
-				if secretRef.SecretID == oldSecretID {
-					return true, nil
-				}
-			}
+		if serviceTasksUseSecretID(taskList, oldSecretID) {
+			return true, nil
 		}
 	}
 
 	return false, nil
+}
+
+func (d *SecretsDriver) listServiceTasks(ctx context.Context, serviceID string) ([]swarm.Task, error) {
+	taskList, err := d.dockerClient.TaskList(ctx, swarm.TaskListOptions{
+		Filters: filtersForService(serviceID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tasks for service %s: %v", serviceID, err)
+	}
+
+	return taskList, nil
+}
+
+func serviceTasksUseSecretID(tasks []swarm.Task, secretID string) bool {
+	for _, task := range tasks {
+		if !isRunningTask(task) {
+			continue
+		}
+		if taskUsesSecretID(task, secretID) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isRunningTask(task swarm.Task) bool {
+	return task.DesiredState == swarm.TaskStateRunning && task.Status.State == swarm.TaskStateRunning
+}
+
+func taskUsesSecretID(task swarm.Task, secretID string) bool {
+	if task.Spec.ContainerSpec == nil {
+		return false
+	}
+
+	for _, secretRef := range task.Spec.ContainerSpec.Secrets {
+		if secretRef != nil && secretRef.SecretID == secretID {
+			return true
+		}
+	}
+
+	return false
 }
 
 func filtersForService(serviceID string) filters.Args {

--- a/driver.go
+++ b/driver.go
@@ -479,8 +479,13 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 		return nil
 	}
 
+	// The initial request context may already be expired after a rolling update completes,
+	// so use a fresh timeout for final secret cleanup.
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cleanupCancel()
+
 	// Remove the old secret only after services are updated and no running task uses it.
-	if err := d.dockerClient.SecretRemove(ctx, existingSecret.ID); err != nil {
+	if err := d.dockerClient.SecretRemove(cleanupCtx, existingSecret.ID); err != nil {
 		log.Warnf("Failed to remove old secret version %s: %v", existingSecret.ID, err)
 		// Don't return error as the new secret was created and services updated successfully
 	}
@@ -518,14 +523,14 @@ func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretNa
 			newSecretName,
 			newSecretID,
 			updatedSecrets,
-			)
-			if needsUpdate {
-				if err := d.applyServiceSecretUpdate(ctx, service, updatedSecrets); err != nil {
-					return nil, err
-				}
-				updatedServices = append(updatedServices, service.Spec.Name)
-				updatedServiceIDs = append(updatedServiceIDs, service.ID)
+		)
+		if needsUpdate {
+			if err := d.applyServiceSecretUpdate(ctx, service, updatedSecrets); err != nil {
+				return nil, err
 			}
+			updatedServices = append(updatedServices, service.Spec.Name)
+			updatedServiceIDs = append(updatedServiceIDs, service.ID)
+		}
 	}
 
 	if len(updatedServices) > 0 {

--- a/driver.go
+++ b/driver.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-plugins-helpers/secrets"
@@ -462,8 +463,9 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 
 	log.Printf("Created new version of secret %s with name %s and ID: %s", secretName, newSecretName, createResponse.ID)
 
-	// Update all services that use this secret to point to the new version
-	if err := d.updateServicesSecretReference(secretName, newSecretName, createResponse.ID); err != nil {
+	// Update all services that use this secret to point to the new version.
+	updatedServiceIDs, err := d.updateServicesSecretReference(secretName, newSecretName, createResponse.ID)
+	if err != nil {
 		// try to remove the new secret since service update failed
 		if cleanupErr := d.dockerClient.SecretRemove(ctx, createResponse.ID); cleanupErr != nil {
 			log.Warnf("failed to remove new secret %s after service update error: %v", createResponse.ID, cleanupErr)
@@ -471,7 +473,13 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 		return fmt.Errorf("failed to update services to use new secret: %v", err)
 	}
 
-	// Remove the old secret only after services are updated
+	// Wait until running tasks stop using the old secret before cleanup.
+	if err := d.waitForServicesToStopUsingSecret(updatedServiceIDs, secretName, existingSecret.ID, 2*time.Minute); err != nil {
+		log.Warnf("Delaying old secret cleanup for %s: %v", secretName, err)
+		return nil
+	}
+
+	// Remove the old secret only after services are updated and no running task uses it.
 	if err := d.dockerClient.SecretRemove(ctx, existingSecret.ID); err != nil {
 		log.Warnf("Failed to remove old secret version %s: %v", existingSecret.ID, err)
 		// Don't return error as the new secret was created and services updated successfully
@@ -480,18 +488,20 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 	return nil
 }
 
-// updateServicesSecretReference updates all services to use the new secret version
-func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretName, newSecretID string) error {
+// updateServicesSecretReference updates all services to use the new secret version.
+// It returns IDs of services that were updated.
+func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretName, newSecretID string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	// List all services
 	services, err := d.dockerClient.ServiceList(ctx, swarm.ServiceListOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to list services: %v", err)
+		return nil, fmt.Errorf("failed to list services: %v", err)
 	}
 
 	var updatedServices []string
+	var updatedServiceIDs []string
 
 	for _, service := range services {
 		// Check if service uses this secret and update the reference.
@@ -508,20 +518,92 @@ func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretNa
 			newSecretName,
 			newSecretID,
 			updatedSecrets,
-		)
-		if needsUpdate {
-			if err := d.applyServiceSecretUpdate(ctx, service, updatedSecrets); err != nil {
-				return err
+			)
+			if needsUpdate {
+				if err := d.applyServiceSecretUpdate(ctx, service, updatedSecrets); err != nil {
+					return nil, err
+				}
+				updatedServices = append(updatedServices, service.Spec.Name)
+				updatedServiceIDs = append(updatedServiceIDs, service.ID)
 			}
-			updatedServices = append(updatedServices, service.Spec.Name)
-		}
 	}
 
 	if len(updatedServices) > 0 {
 		log.Printf("Updated services to use new secret %s: %v", newSecretName, updatedServices)
 	}
 
-	return nil
+	return updatedServiceIDs, nil
+}
+
+// waitForServicesToStopUsingSecret waits until no running task of the updated services uses the old secret.
+func (d *SecretsDriver) waitForServicesToStopUsingSecret(serviceIDs []string, oldSecretName, oldSecretID string, timeout time.Duration) error {
+	if len(serviceIDs) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		stillInUse, err := d.isOldSecretUsedByRunningTasks(ctx, serviceIDs, oldSecretName, oldSecretID)
+		if err != nil {
+			return err
+		}
+		if !stillInUse {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for services to stop using old secret")
+		case <-ticker.C:
+		}
+	}
+}
+
+func (d *SecretsDriver) isOldSecretUsedByRunningTasks(ctx context.Context, serviceIDs []string, oldSecretName, oldSecretID string) (bool, error) {
+	if oldSecretID == "" {
+		return false, fmt.Errorf("old secret ID is required for usage detection")
+	}
+
+	for _, serviceID := range serviceIDs {
+		taskList, err := d.dockerClient.TaskList(ctx, swarm.TaskListOptions{
+			Filters: filtersForService(serviceID),
+		})
+		if err != nil {
+			return false, fmt.Errorf("failed to list tasks for service %s: %v", serviceID, err)
+		}
+
+		for _, task := range taskList {
+			if task.DesiredState != swarm.TaskStateRunning || task.Status.State != swarm.TaskStateRunning {
+				continue
+			}
+			if task.Spec.ContainerSpec == nil {
+				continue
+			}
+
+			for _, secretRef := range task.Spec.ContainerSpec.Secrets {
+				if secretRef == nil {
+					continue
+				}
+
+				if secretRef.SecretID == oldSecretID {
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func filtersForService(serviceID string) filters.Args {
+	args := filters.NewArgs()
+	args.Add("service", serviceID)
+	return args
 }
 
 func buildUpdatedSecretReferences(


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change 
ex: - [x] Refactor
-->

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Mention the secrets provider 

Provider-agnostic (rotation flow in core driver), validated with HashiCorp Vault.


## Description

This PR fixes rotation cleanup behavior where the old Docker secret could be removed too early, or retained incorrectly during rolling updates.

### What changed
- Updated rotation flow in `driver.go` to delay old secret removal until updated services no longer have running tasks using the old secret ID.
- `updateServicesSecretReference(...)` now returns the list of updated service IDs.
- Added wait/poll logic:
  - `waitForServicesToStopUsingSecret(...)`
  - `isOldSecretUsedByRunningTasks(...)`
- If timeout occurs while old secret is still in use, the old secret is retained and a warning is logged (safe behavior).
- Added a defensive nil guard for `service.Spec.TaskTemplate.ContainerSpec`.
- Replaced deprecated `types.TaskListOptions` usage with `swarm.TaskListOptions`.

### Why
Docker Swarm service updates are asynchronous/rolling. Deleting the old secret immediately after `ServiceUpdate` can impact replicas that have not switched yet.



## Commands & Configuration to test

```bash
# compile check
GOCACHE=/tmp/go-build go test ./...

# manual rotation validation (Vault, 3 replicas, rolling update)
docker swarm init 2>/dev/null || true

docker rm -f rt-vault 2>/dev/null || true
docker run -d --name rt-vault -p 8200:8200 \
  -e VAULT_DEV_ROOT_TOKEN_ID=root \
  hashicorp/vault:latest server -dev

docker exec rt-vault sh -lc \
  'VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=root vault kv put secret/database/mysql password=v1'

docker plugin disable swarm-external-secrets:latest 2>/dev/null || true
docker plugin set swarm-external-secrets:latest \
  SECRETS_PROVIDER="vault" \
  VAULT_ADDR="http://127.0.0.1:8200" \
  VAULT_AUTH_METHOD="token" \
  VAULT_TOKEN="root" \
  VAULT_MOUNT_PATH="secret" \
  ENABLE_ROTATION="true" \
  ROTATION_INTERVAL="5s" \
  ENABLE_MONITORING="false"
docker plugin enable swarm-external-secrets:latest
```

Use stack with 3 replicas and rolling update config (parallelism: 1, delay: 20s), then rotate to v2:
```bash
docker exec rt-vault sh -lc \
  'VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=root vault kv put secret/database/mysql password=v2'
```
Validation:

During rolling update: old secret remains present.
After all replicas converge to new secret: old secret is removed.

## Screenshots & Logs
Service logs showed transition from v1 to v2 across replicas. : 

<img width="1293" height="508" alt="Screenshot From 2026-03-18 17-51-11" src="https://github.com/user-attachments/assets/983e73c4-267b-4bbb-9aa1-1602b9da13a9" />

Final check after convergence:

<img width="1153" height="79" alt="Screenshot From 2026-03-18 18-23-34" src="https://github.com/user-attachments/assets/0b02ed44-01a0-4618-87bd-c2fcac0ac817" />


## Related Tickets & Documents

- Related Issue #105 
- Closes #78 


## Was this PR authored or co-authored using generative AI tooling?
Yes (assisted drafting and iteration). All changes were manually reviewed, validated locally, and tested before submission.