### PR TITLE
fix: use configured mount path instead of hardcoded "secret/data/" in rotation tracking

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -344,8 +344,13 @@ func (d *SecretsDriver) rotateSecret(secretInfo *providers.SecretInfo) error {
 	switch secretInfo.Provider {
 	case "vault":
 		req.SecretLabels["vault_field"] = secretInfo.SecretField
-		// Extract the specific path part from the full path
-		req.SecretLabels["vault_path"] = strings.TrimPrefix(secretInfo.SecretPath, "secret/data/")
+		// Extract the specific path part from the full path by trimming the mount prefix
+		mountPath := d.getVaultMountPath()
+		if mountPath == "secret" {
+			req.SecretLabels["vault_path"] = strings.TrimPrefix(secretInfo.SecretPath, mountPath+"/data/")
+		} else {
+			req.SecretLabels["vault_path"] = strings.TrimPrefix(secretInfo.SecretPath, mountPath+"/")
+		}
 	case "aws":
 		req.SecretLabels["aws_field"] = secretInfo.SecretField
 		req.SecretLabels["aws_secret_name"] = secretInfo.SecretPath
@@ -357,7 +362,12 @@ func (d *SecretsDriver) rotateSecret(secretInfo *providers.SecretInfo) error {
 		req.SecretLabels["azure_secret_name"] = secretInfo.SecretPath
 	case "openbao":
 		req.SecretLabels["openbao_field"] = secretInfo.SecretField
-		req.SecretLabels["openbao_path"] = strings.TrimPrefix(secretInfo.SecretPath, "secret/data/")
+		mountPath := d.getOpenBaoMountPath()
+		if mountPath == "secret" {
+			req.SecretLabels["openbao_path"] = strings.TrimPrefix(secretInfo.SecretPath, mountPath+"/data/")
+		} else {
+			req.SecretLabels["openbao_path"] = strings.TrimPrefix(secretInfo.SecretPath, mountPath+"/")
+		}
 	}
 
 	// Get the new secret value from the provider
@@ -570,30 +580,56 @@ func (d *SecretsDriver) Stop() error {
 
 // Helper methods for building provider-specific secret paths/names
 
+// getVaultMountPath returns the configured Vault mount path, defaulting to "secret"
+func (d *SecretsDriver) getVaultMountPath() string {
+	if mp, ok := d.config.Settings["VAULT_MOUNT_PATH"]; ok && mp != "" {
+		return mp
+	}
+	return "secret"
+}
+
+// getOpenBaoMountPath returns the configured OpenBao mount path, defaulting to "secret"
+func (d *SecretsDriver) getOpenBaoMountPath() string {
+	if mp, ok := d.config.Settings["OPENBAO_MOUNT_PATH"]; ok && mp != "" {
+		return mp
+	}
+	return "secret"
+}
+
+// buildMountedPath builds a full secret path using the given mount path.
+// For the default "secret" mount (KV v2), paths include a "/data/" segment.
+// For custom mounts, the path is used directly.
+func buildMountedPath(mountPath, subPath string) string {
+	if mountPath == "secret" {
+		return fmt.Sprintf("%s/data/%s", mountPath, subPath)
+	}
+	return fmt.Sprintf("%s/%s", mountPath, subPath)
+}
+
 func (d *SecretsDriver) buildVaultSecretPath(req secrets.Request) string {
-	// Use custom path from labels if provided
+	mountPath := d.getVaultMountPath()
+
 	if customPath, exists := req.SecretLabels["vault_path"]; exists {
-		return fmt.Sprintf("secret/data/%s", customPath)
+		return buildMountedPath(mountPath, customPath)
 	}
 
-	// Default path structure for KV v2
 	if req.ServiceName != "" {
-		return fmt.Sprintf("secret/data/%s/%s", req.ServiceName, req.SecretName)
+		return buildMountedPath(mountPath, fmt.Sprintf("%s/%s", req.ServiceName, req.SecretName))
 	}
-	return fmt.Sprintf("secret/data/%s", req.SecretName)
+	return buildMountedPath(mountPath, req.SecretName)
 }
 
 func (d *SecretsDriver) buildOpenBaoSecretPath(req secrets.Request) string {
-	// Use custom path from labels if provided
+	mountPath := d.getOpenBaoMountPath()
+
 	if customPath, exists := req.SecretLabels["openbao_path"]; exists {
-		return fmt.Sprintf("secret/data/%s", customPath)
+		return buildMountedPath(mountPath, customPath)
 	}
 
-	// Default path structure for KV v2
 	if req.ServiceName != "" {
-		return fmt.Sprintf("secret/data/%s/%s", req.ServiceName, req.SecretName)
+		return buildMountedPath(mountPath, fmt.Sprintf("%s/%s", req.ServiceName, req.SecretName))
 	}
-	return fmt.Sprintf("secret/data/%s", req.SecretName)
+	return buildMountedPath(mountPath, req.SecretName)
 }
 
 func (d *SecretsDriver) buildAWSSecretName(req secrets.Request) string {

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/docker/go-plugins-helpers/secrets"
+)
+
+const (
+	testSecretPath    = "svc/db"
+	testDefaultResult = "secret/data/" + testSecretPath
+	testCustomResult  = "kv/" + testSecretPath
+)
+
+var customVaultMount = map[string]string{"VAULT_MOUNT_PATH": "kv"}
+var customOpenBaoMount = map[string]string{"OPENBAO_MOUNT_PATH": "kv"}
+
+func newRequest(name, service string, labels map[string]string) secrets.Request {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	return secrets.Request{
+		SecretName:   name,
+		ServiceName:  service,
+		SecretLabels: labels,
+	}
+}
+
+func TestBuildSecretPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		settings map[string]string
+		req      secrets.Request
+		expected string
+	}{
+		// Vault — default mount
+		{"vault: label path, default mount", "vault", nil, newRequest("test", "", map[string]string{"vault_path": testSecretPath}), testDefaultResult},
+		{"vault: service fallback, default mount", "vault", nil, newRequest("db", "svc", nil), testDefaultResult},
+		{"vault: name only, default mount", "vault", nil, newRequest("db", "", nil), "secret/data/db"},
+		// Vault — custom mount
+		{"vault: label path, custom mount", "vault", customVaultMount, newRequest("test", "", map[string]string{"vault_path": testSecretPath}), testCustomResult},
+		{"vault: service fallback, custom mount", "vault", customVaultMount, newRequest("db", "svc", nil), testCustomResult},
+		{"vault: name only, custom mount", "vault", customVaultMount, newRequest("db", "", nil), "kv/db"},
+		// OpenBao
+		{"openbao: label path, default mount", "openbao", nil, newRequest("test", "", map[string]string{"openbao_path": testSecretPath}), testDefaultResult},
+		{"openbao: label path, custom mount", "openbao", customOpenBaoMount, newRequest("test", "", map[string]string{"openbao_path": testSecretPath}), testCustomResult},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := tt.settings
+			if settings == nil {
+				settings = map[string]string{}
+			}
+			driver := &SecretsDriver{config: &SecretsConfig{Settings: settings}}
+
+			var got string
+			if tt.provider == "vault" {
+				got = driver.buildVaultSecretPath(tt.req)
+			} else {
+				got = driver.buildOpenBaoSecretPath(tt.req)
+			}
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Read `VAULT_MOUNT_PATH` / `OPENBAO_MOUNT_PATH` from config in `driver.go` instead of hardcoding `"secret/data/"` prefix
- Fix `buildVaultSecretPath`, `buildOpenBaoSecretPath`, and `rotateSecret` to use the configured mount path
- For default "secret" mount (KV v2): `{mount}/data/{path}`; for custom mounts: `{mount}/{path}`
- Add unit tests for path-building logic

Fixes #111

## Test plan

- [x] All new unit tests pass (`go test -v`)
- [x] Default "secret" mount behavior unchanged (backward compatible)
- [x] Custom mount paths (e.g. "kv") produce correct paths without "/data/" segment