### PR TITLE
fix: make makim ci.all reproducible for all environments

### DIFF
--- a/.makim.yaml
+++ b/.makim.yaml
@@ -37,7 +37,12 @@ groups:
       
       docs:
         help: Build documentation
-        run:  python3 -m mkdocs build
+        run: |
+          if [ -x ./.venv/bin/python ]; then
+            ./.venv/bin/python -m mkdocs build
+          else
+            python3 -m mkdocs build
+          fi
 
       linter:
         help: Run linting tools

--- a/scripts/check_plugin_service.sh
+++ b/scripts/check_plugin_service.sh
@@ -3,11 +3,23 @@
 set -ex  # Exit on any error
 cd -- "$(dirname -- "$0")" || exit 1
 
-# Check if service ID is provided
 if [ $# -eq 0 ]; then
-  echo "Please provide the service ID as argument"
-  echo "Usage: $0 <service-id>"
-  exit 1
+  echo "No service ID provided; running local plugin health check mode."
+  echo "=== Local Plugin Status ==="
+  docker plugin ls
+
+  if docker plugin inspect swarm-external-secrets:temp &>/dev/null; then
+    echo -e "\n=== swarm-external-secrets:temp Details ==="
+    docker plugin inspect swarm-external-secrets:temp | grep -E 'Name|Enabled|Config'
+  elif docker plugin inspect swarm-external-secrets:latest &>/dev/null; then
+    echo -e "\n=== swarm-external-secrets:latest Details ==="
+    docker plugin inspect swarm-external-secrets:latest | grep -E 'Name|Enabled|Config'
+  else
+    echo "No local swarm-external-secrets plugin found"
+    exit 1
+  fi
+
+  exit 0
 fi
 
 SERVICE_ID=$1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -32,25 +32,20 @@ docker plugin create swarm-external-secrets:temp ./plugin
 echo -e "${RED}Clean up plugin directory${DEF}"
 rm -rf ./plugin
 
+echo -e "${RED}Set plugin configuration${DEF}"
+docker plugin set swarm-external-secrets:temp \
+    SECRETS_PROVIDER="aws" \
+    AWS_REGION="us-east-1" \
+    ENABLE_ROTATION="false" \
+    ENABLE_MONITORING="false" \
+    gid=0 \
+    uid=0
+
 echo -e "${RED}Enable the plugin${DEF}"
 docker plugin enable swarm-external-secrets:temp
 
 echo -e "${RED}Check plugin status${DEF}"
 docker plugin ls
-
-# Add debugging and set proper permissions
-echo -e "${RED}Set plugin permissions${DEF}"
-docker plugin set swarm-external-secrets:temp gid=0 uid=0
-
-echo -e "${RED}Set plugin configuration${DEF}"
-docker plugin set swarm-external-secrets:temp \
-    VAULT_ADDR="https://152.53.244.80:8200" \
-    VAULT_AUTH_METHOD="approle" \
-    VAULT_ROLE_ID="8ff294a6-9d5c-c5bb-b494-bc0bfe02a97e" \
-    VAULT_SECRET_ID="aedde801-0616-18a5-a62d-c6d7eb483cff" \
-    VAULT_MOUNT_PATH="secret" \
-    VAULT_ENABLE_ROTATION="true" \
-    VAULT_ROTATION_INTERVAL="1m"
 
 echo -e "${GRN}Plugin setup complete. Check plugin logs with:${DEF}"
 echo "docker plugin inspect swarm-external-secrets:temp"


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change 
ex: - [x] Refactor
-->

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Mention the secrets provider 

## Description

Running `makim ci.all` fails for different environments due to 3 issues:
1. Docs step uses system `python3` instead of project `.venv`, causing `No module named mkdocs` error.
2. `test.sh` enables the plugin before setting configuration, causing `plugin.sock` errors. Also contains hardcoded Vault credentials that no longer work.
3. `check_plugin_service.sh` exits with error when called with no arguments, but `makim ci.all` calls it with no arguments.

I discovered this issue while doing this PR: https://github.com/sugar-org/swarm-external-secrets/pull/122 and trying to pass tests.

I did: 
1. `.makim.yaml`: prefer `.venv/bin/python` for docs build.
2. `test.sh`: set configuration before enable, use neutral CI-safe defaults.
3. `check_plugin_service.sh`: support no-arg local health check mode.


## Commands & Configuration to test

Ran makim ci.all &all steps passed (as recommended in the guidelines here: https://sugar-org.github.io/swarm-external-secrets/CONTRIBUTING/#google-summer-of-code-2026). 

## Screenshots & Logs

## Related Tickets & Documents

- Related Issue #
- Closes #


## Was this PR authored or co-authored using generative AI tooling?
Yes. Claude was used as a debugging and learning aid during development. However, all code has been reviewed, understood, and verified by me. I can explain every decision made.