### PR TITLE
fix: restore monitoring dashboard rendering

### DIFF
--- a/monitoring/web.go
+++ b/monitoring/web.go
@@ -65,7 +65,7 @@ func (wi *WebInterface) handleDashboard(w http.ResponseWriter, r *http.Request) 
 	metrics := wi.monitor.GetMetrics()
 	health := wi.monitor.GetHealthStatus()
 
-	tmpl := template.Must(template.New("dashboard").Parse(dashboardTemplate))
+	tmpl := template.Must(template.New("dashboard").Funcs(dashboardFuncMap()).Parse(dashboardTemplate))
 
 	data := struct {
 		Metrics *Metrics
@@ -78,6 +78,42 @@ func (wi *WebInterface) handleDashboard(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set(contentTypeHeader, "text/html")
 	if err := tmpl.Execute(w, data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func dashboardFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"div": func(a interface{}, b interface{}) float64 {
+			af := toFloat64(a)
+			bf := toFloat64(b)
+			if bf == 0 {
+				return 0
+			}
+			return af / bf
+		},
+	}
+}
+
+func toFloat64(v interface{}) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case int32:
+		return float64(n)
+	case uint:
+		return float64(n)
+	case uint64:
+		return float64(n)
+	case uint32:
+		return float64(n)
+	default:
+		return 0
 	}
 }
 

--- a/monitoring/web.go
+++ b/monitoring/web.go
@@ -247,7 +247,7 @@ const dashboardTemplate = `
 <body>
     <div class="container">
         <div class="header">
-            <h1>🔐 Vault Swarm Plugin Monitor</h1>
+            <h1>Vault Swarm Plugin Monitor</h1>
             <p>Real-time monitoring of secret provider plugin</p>
             <span class="status {{if .Health.healthy}}healthy{{else}}unhealthy{{end}}">
                 {{if .Health.healthy}}HEALTHY{{else}}UNHEALTHY{{end}}
@@ -256,7 +256,7 @@ const dashboardTemplate = `
 
         <div class="grid">
             <div class="card">
-                <h3>📊 System Metrics</h3>
+                <h3>System Metrics</h3>
                 <div class="metric">
                     <span class="metric-label">Goroutines:</span>
                     <span class="metric-value">{{.Metrics.NumGoroutines}}</span>
@@ -280,7 +280,7 @@ const dashboardTemplate = `
             </div>
 
             <div class="card">
-                <h3>🔄 Secret Rotation</h3>
+                <h3>Secret Rotation</h3>
                 <div class="metric">
                     <span class="metric-label">Total Rotations:</span>
                     <span class="metric-value">{{.Metrics.SecretRotations}}</span>
@@ -304,7 +304,7 @@ const dashboardTemplate = `
             </div>
 
             <div class="card">
-                <h3>⏱️ Uptime & Status</h3>
+                <h3>Uptime & Status</h3>
                 <div class="metric">
                     <span class="metric-label">Uptime:</span>
                     <span class="metric-value">{{printf "%.2f" .Health.uptime_seconds}} seconds</span>
@@ -315,7 +315,7 @@ const dashboardTemplate = `
                 </div>
                 <div class="metric">
                     <span class="metric-label">Ticker Health:</span>
-                    <span class="metric-value">{{if .Health.ticker_healthy}}✅ Healthy{{else}}❌ Unhealthy{{end}}</span>
+                    <span class="metric-value">{{if .Health.ticker_healthy}}Healthy{{else}}Unhealthy{{end}}</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">Last GC:</span>

--- a/monitoring/web_test.go
+++ b/monitoring/web_test.go
@@ -1,0 +1,34 @@
+package monitoring
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandleDashboardRendersHTML(t *testing.T) {
+	monitor := NewMonitor(time.Second)
+	monitor.SetRotationInterval(10 * time.Second)
+
+	web := NewWebInterface(monitor, 8080)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	web.handleDashboard(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	if got := rec.Header().Get(contentTypeHeader); got != "text/html" {
+		t.Fatalf("expected content type %q, got %q", "text/html", got)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Vault Swarm Plugin Monitor") {
+		t.Fatalf("expected dashboard HTML in response body, got %q", body)
+	}
+}


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change 
ex: - [x] Refactor
-->

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Mention the secrets provider 

N/A

## Description

This PR fixes the monitoring dashboard render failure on `/`.

The dashboard template uses a `div` helper to format memory values, but no template function was registered before parsing the template. Because of that, the HTML dashboard route was failing at runtime while other monitoring endpoints such as `/metrics`, `/health`, and `/api/metrics` continued to work.

This change registers the missing template helper and adds a regression test for the dashboard handler.



## Commands & Configuration to test

```bash
env GOCACHE=/tmp/go-build-cache go test ./monitoring

// For manual verification, I also ran the monitoring web interface locally and checked:

curl -i http://127.0.0.1:8080/
curl -i http://127.0.0.1:8080/metrics
curl -i http://127.0.0.1:8080/health
curl -i http://127.0.0.1:8080/api/metrics
```


## Screenshots & Logs

Before the fix:

<img width="1369" height="720" alt="Screenshot From 2026-04-12 00-06-07" src="https://github.com/user-attachments/assets/c1de1044-1583-4e48-8b31-d76c7353657d" />

 --- 
 
 After the fix:
 
<img width="1913" height="934" alt="Screenshot From 2026-04-13 18-25-15" src="https://github.com/user-attachments/assets/ea15ca51-01ae-426f-8691-84ffb9028b1f" />




## Related Tickets & Documents

- Related Issue #129 
- Closes #129 
