### PR TITLE
fix: remove stale Vault prefixed rotation env vars and align scripts with runtime config.

### DIFF
--- a/config.json
+++ b/config.json
@@ -53,16 +53,6 @@
       "settable": ["value"]
     },
     {
-      "name": "VAULT_ENABLE_ROTATION",
-      "description": "Enable automatic secret rotation (true/false)",
-      "settable": ["value"]
-    },
-    {
-      "name": "VAULT_ROTATION_INTERVAL",
-      "description": "Secret rotation check interval (e.g., 5m, 1h)",
-      "settable": ["value"]
-    },
-    {
       "name": "SECRETS_PROVIDER",
       "description": "Secrets provider type (e.g., vault, openbao)",
       "settable": ["value"]
@@ -104,12 +94,12 @@
     },
     {
       "name": "ENABLE_ROTATION",
-      "description": "Enable OpenBao secret rotation (true/false)",
+      "description": "Enable automatic secret rotation (true/false)",
       "settable": ["value"]
     },
     {
       "name": "ROTATION_INTERVAL",
-      "description": "OpenBao secret rotation check interval (e.g., 5m, 1h)",
+      "description": "Secret rotation check interval (e.g., 5m, 1h)",
       "settable": ["value"]
     },
     {

--- a/scripts/demo-rotation.sh
+++ b/scripts/demo-rotation.sh
@@ -34,8 +34,8 @@ docker plugin set swarm-external-secrets:latest \
     VAULT_AUTH_METHOD="token" \
     VAULT_TOKEN="your-vault-token" \
     VAULT_MOUNT_PATH="secret" \
-    VAULT_ENABLE_ROTATION="true" \
-    VAULT_ROTATION_INTERVAL="30s" || echo "Plugin configuration may already be set"
+    ENABLE_ROTATION="true" \
+    ROTATION_INTERVAL="30s" || echo "Plugin configuration may already be set"
 echo -e "${GRN}Plugin configured with 30-second rotation interval${DEF}"
 echo
 # Create a simple demo stack

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,8 +49,8 @@ rm -rf ./plugin
 #     VAULT_AUTH_METHOD="token" \
 #     VAULT_TOKEN="" \
 #     VAULT_MOUNT_PATH="secret" \
-#     VAULT_ENABLE_ROTATION="true" \
-#     VAULT_ROTATION_INTERVAL="5s" \
+#     ENABLE_ROTATION="true" \
+#     ROTATION_INTERVAL="5s" \
 #     ENABLE_MONITORING="true" \
 #     MONITORING_PORT="8080"
 
@@ -60,7 +60,7 @@ rm -rf ./plugin
 #     OPENBAO_ADDR="" \
 #     OPENBAO_TOKEN="" \
 #     OPENBAO_MOUNT_PATH="secret" \
-#     VAULT_ENABLE_ROTATION="true"
+#     ENABLE_ROTATION="true"
 
 export GOOGLE_CREDENTIALS=$(jq -c . ../graphic-transit-458312-f7-44c20b0e486c.json)
 docker plugin set swarm-external-secrets:latest \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -49,8 +49,8 @@ docker plugin set swarm-external-secrets:temp \
     VAULT_ROLE_ID="8ff294a6-9d5c-c5bb-b494-bc0bfe02a97e" \
     VAULT_SECRET_ID="aedde801-0616-18a5-a62d-c6d7eb483cff" \
     VAULT_MOUNT_PATH="secret" \
-    VAULT_ENABLE_ROTATION="true" \
-    VAULT_ROTATION_INTERVAL="1m"
+    ENABLE_ROTATION="true" \
+    ROTATION_INTERVAL="1m"
 
 echo -e "${GRN}Plugin setup complete. Check plugin logs with:${DEF}"
 echo "docker plugin inspect swarm-external-secrets:temp"


### PR DESCRIPTION
## Type of change 

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [x] Documentation
- [ ] CI

## Mention the secrets provider 

HashiCorp Vault

## Description

Fixes a rotation configuration mismatch where Vault prefixed rotation environment variables were exposed by the plugin surface, but runtime rotation logic only honored the provider agnostic variables and was dropping the env vars which start with VAULT prefix like enable rotation and rotation interval.

Previously, `config.json` and some setup scripts advertised and used:

- `VAULT_ENABLE_ROTATION`
- `VAULT_ROTATION_INTERVAL`

However, runtime configuration in `driver.go` only reads:

- `ENABLE_ROTATION`
- `ROTATION_INTERVAL`

This caused silent misconfiguration for Vault users, because setting the Vault-prefixed rotation variables had no effect.
This PR updates the implementation so that:

- stale Vault-prefixed rotation env vars are removed from `config.json`
- plugin-exposed rotation configuration is now provider-agnostic
- Vault demo/test/deploy scripts use `ENABLE_ROTATION` and `ROTATION_INTERVAL`
- rotation documentation and plugin behavior are aligned with actual runtime handling

After this change, rotation settings are configured consistently through the generic env vars regardless of provider, while runtime still only enables rotation for providers that implement `SupportsRotation()`.


## Commands & Configuration to test

To test this :

```bash
docker plugin set swarm-external-secrets:latest \
    SECRETS_PROVIDER="vault" \
    VAULT_ADDR="http://127.0.0.1:8200" \
    VAULT_AUTH_METHOD="token" \
    VAULT_TOKEN="root" \
    VAULT_MOUNT_PATH="secret" \
    ENABLE_ROTATION="false" \
    ROTATION_INTERVAL="30s"
```
Validate that:

- ENABLE_ROTATION="false" disables rotation
- ROTATION_INTERVAL="30s" is honored when rotation is enabled
- Vault-prefixed rotation vars are no longer documented/exposed in plugin config

## Related Tickets & Documents

- Closes #133 

