### PR TITLE
fix: move rotation tracking metadata logs to trace

### DIFF
--- a/config.json
+++ b/config.json
@@ -191,6 +191,11 @@
       "name": "OPENBAO_SKIP_VERIFY",
       "description": "Skip TLS certificate verification for OpenBao (true/false)",
       "settable": ["value"]
+    },
+    {
+      "name": "LOG_LEVEL",
+      "description": "Optional log level integer (0-7). 0=panic,1=fatal,2=error,3=warn,4=info,5=debug,6=trace; 7 is also treated as trace. Defaults to info.",
+      "settable": ["value"]
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -194,7 +194,7 @@
     },
     {
       "name": "LOG_LEVEL",
-      "description": "Optional log level integer (0-7). 0=panic,1=fatal,2=error,3=warn,4=info,5=debug,6=trace; 7 is also treated as trace. Defaults to info.",
+      "description": "Optional log level integer (0-6). 0=panic,1=fatal,2=error,3=warn,4=info,5=debug,6=trace. Defaults to info.",
       "settable": ["value"]
     }
   ]

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -71,6 +71,19 @@ vault kv get secret/database/mysql
 
 ## Debug the Plugin
 
+## Configure Logging
+
+By default, the plugin logs at **info** level. You can increase verbosity using either:
+
+- `--debug` (sets log level to `debug`)
+- `LOG_LEVEL` (optional integer `0-6`; `6` enables `trace`)
+
+Example:
+
+```bash
+docker plugin set swarm-external-secrets:latest LOG_LEVEL="6"
+```
+
 ```bash
 sudo journalctl -u docker.service -f \
   | grep plugin_id

--- a/docs/rotation.md
+++ b/docs/rotation.md
@@ -25,6 +25,7 @@ The following environment variables control the rotation behavior:
 |---|---|---|
 | `ENABLE_ROTATION` | Enable/disable automatic rotation | `true` |
 | `ROTATION_INTERVAL` | How often to check for changes | `10s` |
+| `LOG_LEVEL` | Optional log level integer `0-6` (use `6` for trace) | `4` (info) |
 
 ### Example Configuration
 
@@ -100,5 +101,6 @@ If rotation is not working:
 
 - The plugin requires Docker socket access to manage secrets and services
 - Ensure proper Vault authentication and minimal required permissions
+- Secret rotation tracking can include sensitive metadata (paths/fields/service mappings) at `trace` level. Keep production log level at `info`/`warn` unless actively debugging.
 - Monitor logs for unauthorized rotation attempts
 - Consider using shorter rotation intervals for highly sensitive secrets

--- a/driver.go
+++ b/driver.go
@@ -239,7 +239,7 @@ func (d *SecretsDriver) trackSecret(req secrets.Request, value []byte) {
 		secretPath = req.SecretName
 	}
 
-	log.Printf("Current provider %s tracking secret: %s at path: %s with field: %s",
+	log.Tracef("Current provider %s tracking secret: %s at path: %s with field: %s",
 		d.provider.GetProviderName(), req.SecretName, secretPath, secretField)
 
 	secretInfo := &providers.SecretInfo{
@@ -271,7 +271,7 @@ func (d *SecretsDriver) trackSecret(req secrets.Request, value []byte) {
 		d.secretTracker[req.SecretName] = secretInfo
 	}
 
-	log.Printf("Tracking secret: %s -> %s (provider: %s, services: %v)",
+	log.Tracef("Tracking secret: %s -> %s (provider: %s, services: %v)",
 		req.SecretName, secretPath, d.provider.GetProviderName(), secretInfo.ServiceNames)
 }
 
@@ -329,7 +329,7 @@ func (d *SecretsDriver) checkForSecretChanges() {
 				return
 			}
 
-			log.Printf("Detected change in secret: %s", secretName)
+			log.Tracef("Detected change in secret: %s", secretName)
 			d.handleSecretRotationResult(secretName, secretInfo)
 		}(secretName, secretInfo)
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/docker/go-plugins-helpers/secrets"
@@ -22,7 +24,25 @@ func main() {
 		log.Println("Vault Secrets Provider v1.0.0")
 		return
 	}
-	if *flDebug {
+
+	// Default to InfoLevel; allow override via LOG_LEVEL (0-7) or --debug.
+	log.SetLevel(log.InfoLevel)
+	if lvlStr, ok := os.LookupEnv("LOG_LEVEL"); ok {
+		lvlStr = strings.TrimSpace(lvlStr)
+		if lvlStr != "" {
+			n, err := strconv.Atoi(lvlStr)
+			if err != nil || n < 0 || n > 7 {
+				log.Warnf("Invalid LOG_LEVEL=%q; expected integer 0-7. Using default level %s.", lvlStr, log.GetLevel())
+			} else {
+				// logrus supports 0-6 (panic..trace); accept 7 as trace for compatibility.
+				if n == 7 {
+					n = int(log.TraceLevel)
+				}
+				log.SetLevel(log.Level(n))
+				log.Debugf("Log level set from LOG_LEVEL=%s (%s)", lvlStr, log.GetLevel())
+			}
+		}
+	} else if *flDebug {
 		log.SetLevel(log.DebugLevel)
 	}
 

--- a/main.go
+++ b/main.go
@@ -12,6 +12,39 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func configureLogLevel(debugFlag bool) {
+	// Default to InfoLevel; allow override via LOG_LEVEL (0-6) or --debug.
+	log.SetLevel(log.InfoLevel)
+
+	if lvlStr, ok := os.LookupEnv("LOG_LEVEL"); ok {
+		if lvl, err := parseLogLevel(lvlStr); err != nil {
+			log.Warnf("Invalid LOG_LEVEL=%q; expected integer 0-6. Using default level %s.", lvlStr, log.GetLevel())
+		} else {
+			log.SetLevel(lvl)
+			log.Debugf("Log level set from LOG_LEVEL=%s (%s)", strings.TrimSpace(lvlStr), log.GetLevel())
+		}
+		return
+	}
+
+	if debugFlag {
+		log.SetLevel(log.DebugLevel)
+	}
+}
+
+func parseLogLevel(s string) (log.Level, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return log.InfoLevel, nil
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 || n > 6 {
+		return log.InfoLevel, err
+	}
+
+	return log.Level(n), nil
+}
+
 func main() {
 	log.Print("Starting Vault Secrets Provider...")
 	var (
@@ -25,26 +58,7 @@ func main() {
 		return
 	}
 
-	// Default to InfoLevel; allow override via LOG_LEVEL (0-7) or --debug.
-	log.SetLevel(log.InfoLevel)
-	if lvlStr, ok := os.LookupEnv("LOG_LEVEL"); ok {
-		lvlStr = strings.TrimSpace(lvlStr)
-		if lvlStr != "" {
-			n, err := strconv.Atoi(lvlStr)
-			if err != nil || n < 0 || n > 7 {
-				log.Warnf("Invalid LOG_LEVEL=%q; expected integer 0-7. Using default level %s.", lvlStr, log.GetLevel())
-			} else {
-				// logrus supports 0-6 (panic..trace); accept 7 as trace for compatibility.
-				if n == 7 {
-					n = int(log.TraceLevel)
-				}
-				log.SetLevel(log.Level(n))
-				log.Debugf("Log level set from LOG_LEVEL=%s (%s)", lvlStr, log.GetLevel())
-			}
-		}
-	} else if *flDebug {
-		log.SetLevel(log.DebugLevel)
-	}
+	configureLogLevel(*flDebug)
 
 	// Initialize the Vault driver
 	driver, err := NewDriver()

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ docker plugin set swarm-external-secrets:latest \
        VAULT_ADDR="https://your-vault-server:8200" \
        VAULT_AUTH_METHOD="token" \
        VAULT_TOKEN="your-vault-token" \
+       LOG_LEVEL="4" \
        ENABLE_ROTATION="true"
    ```
 

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -103,6 +103,7 @@ deploy_stack "${COMPOSE_FILE}" "${STACK_NAME}" 60
 info "Logging service output..."
 sleep 10
 log_stack "${STACK_NAME}" "app"
+assert_no_sensitive_rotation_metadata_logs
 
 # Compare password == logged secret
 info "Verifying secret value matches expected password..."
@@ -118,6 +119,7 @@ success "Secret rotated to: ${SECRET_VALUE_ROTATED}"
 
 info "Waiting for plugin rotation interval (15s)..."
 sleep 30
+assert_no_sensitive_rotation_metadata_logs
 
 info "Logging service output after rotation..."
 log_stack "${STACK_NAME}" "app"

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -15,6 +15,36 @@ success() { echo -e "${GRN}[PASS]${DEF} $*"; }
 error()   { echo -e "${RED}[FAIL]${DEF} $*" >&2; }
 die()     { error "$*"; exit 1; }
 
+docker_daemon_logs() {
+    # Best-effort: plugin logs are routed through Docker daemon logs.
+    # In CI, journald is usually available; fall back gracefully if not.
+    if command -v journalctl >/dev/null 2>&1; then
+        if command -v sudo >/dev/null 2>&1; then
+            sudo journalctl -u docker.service --no-pager -n 2000 2>/dev/null || true
+        else
+            journalctl -u docker.service --no-pager -n 2000 2>/dev/null || true
+        fi
+        return 0
+    fi
+    return 0
+}
+
+assert_no_sensitive_rotation_metadata_logs() {
+    # Ensure trace-only rotation metadata isn't emitted at default log levels.
+    # We look for the exact strings used by the driver.
+    local logs
+    logs="$(docker_daemon_logs)"
+    if echo "${logs}" | grep -Fq "tracking secret:"; then
+        die "Sensitive rotation metadata leaked into logs (found: 'tracking secret:')"
+    fi
+    if echo "${logs}" | grep -Fq "Tracking secret:"; then
+        die "Sensitive rotation metadata leaked into logs (found: 'Tracking secret:')"
+    fi
+    if echo "${logs}" | grep -Fq "Detected change in secret:"; then
+        die "Sensitive rotation metadata leaked into logs (found: 'Detected change in secret:')"
+    fi
+}
+
 # Build plugin (mirrors build.sh / test.sh pattern exactly)
 build_plugin() {
     echo -e "${RED}Remove existing plugin if it exists${DEF}"

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -43,6 +43,8 @@ assert_no_sensitive_rotation_metadata_logs() {
     if echo "${logs}" | grep -Fq "Detected change in secret:"; then
         die "Sensitive rotation metadata leaked into logs (found: 'Detected change in secret:')"
     fi
+
+    return 0
 }
 
 # Build plugin (mirrors build.sh / test.sh pattern exactly)

--- a/scripts/tests/smoke-test-openbao.sh
+++ b/scripts/tests/smoke-test-openbao.sh
@@ -102,6 +102,7 @@ deploy_stack "${COMPOSE_FILE}" "${STACK_NAME}" 60
 info "Logging service output..."
 sleep 10
 log_stack "${STACK_NAME}" "app"
+assert_no_sensitive_rotation_metadata_logs
 
 # Compare password == logged secret
 info "Verifying secret value matches expected password..."
@@ -126,6 +127,7 @@ sleep 15
 
 info "Waiting for new container to start after rotation (10s)..."
 sleep 10
+assert_no_sensitive_rotation_metadata_logs
 
 info "Logging service output after rotation..."
 log_stack "${STACK_NAME}" "app"

--- a/scripts/tests/smoke-test-vault.sh
+++ b/scripts/tests/smoke-test-vault.sh
@@ -105,6 +105,7 @@ deploy_stack "${COMPOSE_FILE}" "${STACK_NAME}" 60
 info "Logging service output..."
 sleep 10
 log_stack "${STACK_NAME}" "app"
+assert_no_sensitive_rotation_metadata_logs
 
 # Compare password == logged secret
 info "Verifying secret value matches expected password..."
@@ -129,6 +130,7 @@ sleep 15
 
 info "Waiting for new container to start after rotation (10s)..."
 sleep 10
+assert_no_sensitive_rotation_metadata_logs
 
 info "Logging service output after rotation..."
 log_stack "${STACK_NAME}" "app"


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change 
ex: - [x] Refactor
-->

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Mention the secrets provider 
Vault / OpenBao / AWS / GCP / Azure (rotation tracking logging is provider-agnostic)

## Description
- Move rotation-tracking log lines that include secret path/field/service metadata to Trace level to avoid leaking metadata at default log level.
- Default runtime logging is set to **Info**, with an optional `LOG_LEVEL` (0–7) to increase verbosity when needed.
- Retains `--debug` behavior for quick debugging (sets Debug when `LOG_LEVEL` is not set).






## Commands & Configuration to test
Default(no metadata leakage expected):
- `ENABLE_ROTATION`=true (plus whatever provider env you use)
- Run plugin and trigger a secret `Get()`: `go test ./...` or deploy plugin and create/update a service
- Confirm logs do not include secret path/field/services

Trace(metadata visible only when explicitly enabled):
- `LOG_LEVEL=6` (or 7) and `ENABLE_ROTATION=true`
- Confirm trace logs include the rotation-tracking details


## Screenshots & Logs
N/A

## Related Tickets & Documents

- Related Issue #140 
- Closes #140 

