### PR TITLE
feat: add host mounted plugin logging with sidecar compose support and secure log handling.

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,6 +19,12 @@
       "destination": "/var/run/docker.sock",
       "type": "bind",
       "options": ["bind", "rbind"]
+    },
+    {
+      "source": "/run/swarm-external-secrets",
+      "destination": "/run/swarm-external-secrets",
+      "type": "bind",
+      "options": ["bind", "rbind", "rshared"]
     }
   ],
   "env": [
@@ -170,6 +176,16 @@
     {
       "name": "MONITORING_PORT",
       "description": "default 8080",
+      "settable": ["value"]
+    },
+    {
+      "name": "PLUGIN_LOG_PATH",
+      "description": "Path for plugin file logs (default /run/swarm-external-secrets/plugin.log)",
+      "settable": ["value"]
+    },
+    {
+      "name": "PLUGIN_LOG_LEVEL",
+      "description": "Log level (debug, info, warn, error), default info",
       "settable": ["value"]
     },
     {

--- a/config.json
+++ b/config.json
@@ -184,7 +184,7 @@
       "settable": ["value"]
     },
     {
-      "name": "PLUGIN_LOG_LEVEL",
+      "name": "LOG_LEVEL",
       "description": "Log level (debug, info, warn, error), default info",
       "settable": ["value"]
     },

--- a/config.json
+++ b/config.json
@@ -207,11 +207,6 @@
       "name": "OPENBAO_SKIP_VERIFY",
       "description": "Skip TLS certificate verification for OpenBao (true/false)",
       "settable": ["value"]
-    },
-    {
-      "name": "LOG_LEVEL",
-      "description": "Optional log level integer (0-6). 0=panic,1=fatal,2=error,3=warn,4=info,5=debug,6=trace. Defaults to info.",
-      "settable": ["value"]
     }
   ]
 }

--- a/docker-compose.logs.yml
+++ b/docker-compose.logs.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  secrets-logger:
+    image: alpine:3.20
+    command: sh -c "touch /run/swarm-external-secrets/plugin.log && tail -F /run/swarm-external-secrets/plugin.log"
+    volumes:
+      - /run/swarm-external-secrets:/run/swarm-external-secrets:ro
+    restart: unless-stopped

--- a/docker-compose.logs.yml
+++ b/docker-compose.logs.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   secrets-logger:
     image: alpine:3.20
-    command: sh -c "touch /run/swarm-external-secrets/plugin.log && tail -F /run/swarm-external-secrets/plugin.log"
+    command: sh -c "tail -F /run/swarm-external-secrets/plugin.log"
     volumes:
       - /run/swarm-external-secrets:/run/swarm-external-secrets:ro
     restart: unless-stopped

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -71,6 +71,46 @@ vault kv get secret/database/mysql
 
 ## Debug the Plugin
 
+The plugin now writes logs to a host-mounted file by default:
+
+```bash
+tail -F /run/swarm-external-secrets/plugin.log
+```
+
+You can override path and level:
+
+```bash
+docker plugin set swarm-external-secrets:latest \
+  PLUGIN_LOG_PATH="/run/swarm-external-secrets/plugin.log" \
+  PLUGIN_LOG_LEVEL="debug"
+```
+
+To expose plugin logs through `docker compose logs`, use the bundled override file:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.logs.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.logs.yml logs -f secrets-logger
+```
+
+The sidecar service in `docker-compose.logs.yml` is:
+
+```yaml
+services:
+  secrets-logger:
+    image: alpine:3.20
+    command: sh -c "touch /run/swarm-external-secrets/plugin.log && tail -F /run/swarm-external-secrets/plugin.log"
+    volumes:
+      - /run/swarm-external-secrets:/run/swarm-external-secrets:ro
+```
+
+The plugin mount for this path is defined in `config.json`, so make sure the host directory exists:
+
+```bash
+sudo mkdir -p /run/swarm-external-secrets
+```
+
+Daemon logs remain available for fallback troubleshooting:
+
 ```bash
 sudo journalctl -u docker.service -f \
   | grep plugin_id

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -77,6 +77,18 @@ The plugin now writes logs to a host-mounted file by default:
 tail -F /run/swarm-external-secrets/plugin.log
 ```
 
+On Linux, the default plugin log path is `/run/swarm-external-secrets/plugin.log`.
+macOS and Windows filesystems do not support this `/run/**` path by default. On
+those hosts, create a log directory with read/write permissions and set
+`PLUGIN_LOG_PATH` to that file:
+
+```bash
+mkdir -p ./logs
+touch ./logs/plugin.log
+docker plugin set swarm-external-secrets:latest \
+  PLUGIN_LOG_PATH="$PWD/logs/plugin.log"
+```
+
 You can override path and level:
 
 ```bash
@@ -111,6 +123,9 @@ The plugin mount for this path is defined in `config.json`, so make sure the hos
 sudo mkdir -p /run/swarm-external-secrets
 sudo touch /run/swarm-external-secrets/plugin.log
 ```
+
+For macOS and Windows, use the same read/write host directory configured with
+`PLUGIN_LOG_PATH` instead of `/run/swarm-external-secrets`.
 
 Daemon logs remain available for fallback troubleshooting:
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -88,6 +88,8 @@ docker plugin set swarm-external-secrets:latest \
 To expose plugin logs through `docker compose logs`, use the bundled override file:
 
 ```bash
+sudo mkdir -p /run/swarm-external-secrets
+sudo touch /run/swarm-external-secrets/plugin.log
 docker compose -f docker-compose.yml -f docker-compose.logs.yml up -d
 docker compose -f docker-compose.yml -f docker-compose.logs.yml logs -f secrets-logger
 ```
@@ -98,15 +100,16 @@ The sidecar service in `docker-compose.logs.yml` is:
 services:
   secrets-logger:
     image: alpine:3.20
-    command: sh -c "touch /run/swarm-external-secrets/plugin.log && tail -F /run/swarm-external-secrets/plugin.log"
+    command: sh -c "tail -F /run/swarm-external-secrets/plugin.log"
     volumes:
       - /run/swarm-external-secrets:/run/swarm-external-secrets:ro
 ```
 
-The plugin mount for this path is defined in `config.json`, so make sure the host directory exists:
+The plugin mount for this path is defined in `config.json`, so make sure the host directory and log file exist:
 
 ```bash
 sudo mkdir -p /run/swarm-external-secrets
+sudo touch /run/swarm-external-secrets/plugin.log
 ```
 
 Daemon logs remain available for fallback troubleshooting:

--- a/docs/rotation.md
+++ b/docs/rotation.md
@@ -66,11 +66,29 @@ docker plugin set swarm-external-secrets:latest \
 Check plugin logs to monitor rotation activity:
 
 ```bash
-# View plugin logs
-sudo journalctl -u docker.service -f | grep vault
+# View plugin logs from the shared host file
+tail -F /run/swarm-external-secrets/plugin.log
 
-# Check for rotation events
-docker service logs <service-name>
+# Filter rotation events
+tail -F /run/swarm-external-secrets/plugin.log | grep -E "rotation|Failed to rotate|Detected change"
+```
+
+You can also expose these logs through the bundled compose override:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.logs.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.logs.yml logs -f secrets-logger
+```
+
+The sidecar service in `docker-compose.logs.yml` is:
+
+```yaml
+services:
+  secrets-logger:
+    image: alpine:3.20
+    command: sh -c "touch /run/swarm-external-secrets/plugin.log && tail -F /run/swarm-external-secrets/plugin.log"
+    volumes:
+      - /run/swarm-external-secrets:/run/swarm-external-secrets:ro
 ```
 
 ## Benefits

--- a/docs/rotation.md
+++ b/docs/rotation.md
@@ -74,6 +74,18 @@ tail -F /run/swarm-external-secrets/plugin.log
 tail -F /run/swarm-external-secrets/plugin.log | grep -E "rotation|Failed to rotate|Detected change"
 ```
 
+On Linux, the default plugin log path is `/run/swarm-external-secrets/plugin.log`.
+macOS and Windows filesystems do not support this `/run/**` path by default. On
+those hosts, create a log directory with read/write permissions and set
+`PLUGIN_LOG_PATH` to that file:
+
+```bash
+mkdir -p ./logs
+touch ./logs/plugin.log
+docker plugin set swarm-external-secrets:latest \
+  PLUGIN_LOG_PATH="$PWD/logs/plugin.log"
+```
+
 You can also expose these logs through the bundled compose override:
 
 ```bash

--- a/docs/rotation.md
+++ b/docs/rotation.md
@@ -77,6 +77,8 @@ tail -F /run/swarm-external-secrets/plugin.log | grep -E "rotation|Failed to rot
 You can also expose these logs through the bundled compose override:
 
 ```bash
+sudo mkdir -p /run/swarm-external-secrets
+sudo touch /run/swarm-external-secrets/plugin.log
 docker compose -f docker-compose.yml -f docker-compose.logs.yml up -d
 docker compose -f docker-compose.yml -f docker-compose.logs.yml logs -f secrets-logger
 ```
@@ -87,7 +89,7 @@ The sidecar service in `docker-compose.logs.yml` is:
 services:
   secrets-logger:
     image: alpine:3.20
-    command: sh -c "touch /run/swarm-external-secrets/plugin.log && tail -F /run/swarm-external-secrets/plugin.log"
+    command: sh -c "tail -F /run/swarm-external-secrets/plugin.log"
     volumes:
       - /run/swarm-external-secrets:/run/swarm-external-secrets:ro
 ```

--- a/driver.go
+++ b/driver.go
@@ -131,9 +131,10 @@ func NewDriver() (*SecretsDriver, error) {
 
 // Get method implements the secrets.Driver interface
 func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
-	log.Printf("Received secret request for: %s using provider: %s", req.SecretName, d.provider.GetProviderName())
+	log.Debugf("Received secret request for: %s using provider: %s", req.SecretName, d.provider.GetProviderName())
 
 	if req.SecretName == "" {
+		log.Warn("Get request rejected: secret name is required")
 		return secrets.Response{
 			Err: "secret name is required",
 		}
@@ -146,13 +147,13 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 	// Get secret from the provider
 	value, err := d.provider.GetSecret(ctx, req)
 	if err != nil {
-		log.Printf("Error getting secret from provider: %v", err)
+		log.Errorf("Error getting secret from provider %s for secret %s: %v", d.provider.GetProviderName(), req.SecretName, err)
 		return secrets.Response{
 			Err: fmt.Sprintf("failed to get secret: %v", err),
 		}
 	}
 
-	log.Printf("Successfully retrieved secret from %s provider", d.provider.GetProviderName())
+	log.Debugf("Successfully retrieved secret from %s provider", d.provider.GetProviderName())
 
 	// Track this secret for monitoring if rotation is enabled
 	if d.config.EnableRotation && d.provider.SupportsRotation() {
@@ -161,9 +162,9 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 
 	// Determine if secret should be reusable (Docker DoNotReuse=true means do not cache/reuse)
 	doNotReuse := d.shouldNotReuse(req)
-	log.Printf("Get secret %q: DoNotReuse=%v (Swarm may reuse cached value when false)", req.SecretName, doNotReuse)
+	log.Debugf("Get secret %q: DoNotReuse=%v (Swarm may reuse cached value when false)", req.SecretName, doNotReuse)
 
-	log.Printf("Successfully returning secret value")
+	log.Debug("Successfully returning secret value")
 	return secrets.Response{
 		Value:      value,
 		DoNotReuse: doNotReuse,
@@ -178,10 +179,10 @@ func (d *SecretsDriver) shouldNotReuse(req secrets.Request) bool {
 		v := strings.ToLower(strings.TrimSpace(reuse))
 		allowReuse := v == "true"
 		if allowReuse {
-			log.Printf("secret_reuse=%q for %q: allowing Swarm reuse (DoNotReuse=false)", reuse, req.SecretName)
+			log.Debugf("secret_reuse=%q for %q: allowing Swarm reuse (DoNotReuse=false)", reuse, req.SecretName)
 			return false
 		}
-		log.Printf("secret_reuse=%q for %q: disallowing Swarm reuse (DoNotReuse=true)", reuse, req.SecretName)
+		log.Debugf("secret_reuse=%q for %q: disallowing Swarm reuse (DoNotReuse=true)", reuse, req.SecretName)
 		return true
 	}
 
@@ -239,7 +240,7 @@ func (d *SecretsDriver) trackSecret(req secrets.Request, value []byte) {
 		secretPath = req.SecretName
 	}
 
-	log.Printf("Current provider %s tracking secret: %s at path: %s with field: %s",
+	log.Debugf("Current provider %s tracking secret: %s at path: %s with field: %s",
 		d.provider.GetProviderName(), req.SecretName, secretPath, secretField)
 
 	secretInfo := &providers.SecretInfo{
@@ -271,7 +272,7 @@ func (d *SecretsDriver) trackSecret(req secrets.Request, value []byte) {
 		d.secretTracker[req.SecretName] = secretInfo
 	}
 
-	log.Printf("Tracking secret: %s -> %s (provider: %s, services: %v)",
+	log.Debugf("Tracking secret: %s -> %s (provider: %s, services: %v)",
 		req.SecretName, secretPath, d.provider.GetProviderName(), secretInfo.ServiceNames)
 }
 
@@ -311,11 +312,11 @@ func (d *SecretsDriver) checkForSecretChanges() {
 		return
 	}
 
-	log.Printf("Checking %d tracked secrets for changes", len(secrets))
+	log.Debugf("Checking %d tracked secrets for changes", len(secrets))
 
 	for secretName, secretInfo := range secrets {
 		if d.hasSecretChanged(secretInfo) {
-			log.Printf("Detected change in secret: %s", secretName)
+			log.Infof("Detected change in secret: %s", secretName)
 			d.handleSecretRotationResult(secretName, secretInfo)
 		}
 	}
@@ -351,7 +352,7 @@ func (d *SecretsDriver) hasSecretChanged(secretInfo *providers.SecretInfo) bool 
 
 // rotateSecret handles the secret rotation process
 func (d *SecretsDriver) rotateSecret(secretInfo *providers.SecretInfo) error {
-	log.Printf("Starting rotation for secret: %s", secretInfo.DockerSecretName)
+	log.Infof("Starting rotation for secret: %s", secretInfo.DockerSecretName)
 
 	// Create a dummy request to get the new secret value
 	req := secrets.Request{
@@ -399,7 +400,7 @@ func (d *SecretsDriver) rotateSecret(secretInfo *providers.SecretInfo) error {
 	secretInfo.LastUpdated = time.Now()
 	d.trackerMutex.Unlock()
 
-	log.Printf("Successfully rotated secret: %s", secretInfo.DockerSecretName)
+	log.Infof("Successfully rotated secret: %s", secretInfo.DockerSecretName)
 	return nil
 }
 
@@ -444,7 +445,7 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 		return fmt.Errorf("failed to create new secret version: %v", err)
 	}
 
-	log.Printf("Created new version of secret %s with name %s and ID: %s", secretName, newSecretName, createResponse.ID)
+	log.Infof("Created new version of secret %s with name %s and ID: %s", secretName, newSecretName, createResponse.ID)
 
 	// Update all services that use this secret to point to the new version
 	if err := d.updateServicesSecretReference(secretName, newSecretName, createResponse.ID); err != nil {
@@ -502,7 +503,7 @@ func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretNa
 	}
 
 	if len(updatedServices) > 0 {
-		log.Printf("Updated services to use new secret %s: %v", newSecretName, updatedServices)
+		log.Infof("Updated services to use new secret %s: %v", newSecretName, updatedServices)
 	}
 
 	return nil

--- a/driver.go
+++ b/driver.go
@@ -313,9 +313,23 @@ func (d *SecretsDriver) checkForSecretChanges() {
 	}
 
 	log.Debugf("Checking %d tracked secrets for changes", len(secrets))
+	// TODO: Revisit this limit if secret-label fanout or provider latency changes.
+	concurrentSecretChecks := len(secrets) + 1
+
+	sem := make(chan struct{}, concurrentSecretChecks)
+	var wg sync.WaitGroup
 
 	for secretName, secretInfo := range secrets {
-		if d.hasSecretChanged(secretInfo) {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(secretName string, secretInfo *providers.SecretInfo) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			if !d.hasSecretChanged(secretInfo) {
+				return
+			}
+
 			log.Infof("Detected change in secret: %s", secretName)
 			d.handleSecretRotationResult(secretName, secretInfo)
 		}(secretName, secretInfo)

--- a/driver.go
+++ b/driver.go
@@ -240,7 +240,7 @@ func (d *SecretsDriver) trackSecret(req secrets.Request, value []byte) {
 		secretPath = req.SecretName
 	}
 
-	log.Debugf("Current provider %s tracking secret: %s at path: %s with field: %s",
+	log.Tracef("Current provider %s tracking secret: %s at path: %s with field: %s",
 		d.provider.GetProviderName(), req.SecretName, secretPath, secretField)
 
 	secretInfo := &providers.SecretInfo{
@@ -272,7 +272,7 @@ func (d *SecretsDriver) trackSecret(req secrets.Request, value []byte) {
 		d.secretTracker[req.SecretName] = secretInfo
 	}
 
-	log.Debugf("Tracking secret: %s -> %s (provider: %s, services: %v)",
+	log.Tracef("Tracking secret: %s -> %s (provider: %s, services: %v)",
 		req.SecretName, secretPath, d.provider.GetProviderName(), secretInfo.ServiceNames)
 }
 

--- a/logging.go
+++ b/logging.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	defaultPluginLogPath = "/run/swarm-external-secrets/plugin.log"
+	defaultPluginLogDir  = "/run/swarm-external-secrets"
 	defaultMaxLogSize    = int64(10 * 1024 * 1024) // 10MB
 )
 
@@ -29,16 +30,22 @@ func newCappedFileWriter(path string, maxBytes int64) (*cappedFileWriter, error)
 		maxBytes = defaultMaxLogSize
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	resolvedPath, err := validateLogPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(resolvedPath), 0o750); err != nil {
 		return nil, fmt.Errorf("create log directory: %w", err)
 	}
 
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	// #nosec G304 -- path is constrained to /run/swarm-external-secrets by validateLogPath.
+	f, err := os.OpenFile(resolvedPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open log file: %w", err)
 	}
 
-	return &cappedFileWriter{path: path, maxBytes: maxBytes, file: f}, nil
+	return &cappedFileWriter{path: resolvedPath, maxBytes: maxBytes, file: f}, nil
 }
 
 func (w *cappedFileWriter) Write(p []byte) (int, error) {
@@ -84,7 +91,8 @@ func (w *cappedFileWriter) rotateIfNeeded(incoming int64) error {
 		return fmt.Errorf("rotate log file: %w", err)
 	}
 
-	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	// #nosec G304 -- writer path is validated during construction in newCappedFileWriter.
+	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("reopen log file after rotation: %w", err)
 	}
@@ -121,4 +129,18 @@ func parseLogLevel(raw string, debugFlag bool) log.Level {
 		return log.InfoLevel
 	}
 	return parsed
+}
+
+func validateLogPath(path string) (string, error) {
+	cleanPath := filepath.Clean(strings.TrimSpace(path))
+	if cleanPath == "." || cleanPath == string(filepath.Separator) {
+		return "", fmt.Errorf("invalid log path: %q", path)
+	}
+
+	defaultDir := filepath.Clean(defaultPluginLogDir) + string(filepath.Separator)
+	if !strings.HasPrefix(cleanPath, defaultDir) {
+		return "", fmt.Errorf("log path %q must be under %s", cleanPath, defaultPluginLogDir)
+	}
+
+	return cleanPath, nil
 }

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	defaultPluginLogPath = "/run/swarm-external-secrets/plugin.log"
+	defaultMaxLogSize    = int64(10 * 1024 * 1024) // 10MB
+)
+
+// cappedFileWriter appends to a log file and rotates it when max size is exceeded.
+type cappedFileWriter struct {
+	mu       sync.Mutex
+	path     string
+	maxBytes int64
+	file     *os.File
+}
+
+func newCappedFileWriter(path string, maxBytes int64) (*cappedFileWriter, error) {
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxLogSize
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create log directory: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+
+	return &cappedFileWriter{path: path, maxBytes: maxBytes, file: f}, nil
+}
+
+func (w *cappedFileWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if err := w.rotateIfNeeded(int64(len(p))); err != nil {
+		return 0, err
+	}
+
+	return w.file.Write(p)
+}
+
+func (w *cappedFileWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		return nil
+	}
+	return w.file.Close()
+}
+
+func (w *cappedFileWriter) rotateIfNeeded(incoming int64) error {
+	info, err := w.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat log file: %w", err)
+	}
+
+	if info.Size()+incoming <= w.maxBytes {
+		return nil
+	}
+
+	if err := w.file.Close(); err != nil {
+		return fmt.Errorf("close log file for rotation: %w", err)
+	}
+
+	rotatedPath := w.path + ".1"
+	if err := os.Remove(rotatedPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove previous rotated log: %w", err)
+	}
+
+	if err := os.Rename(w.path, rotatedPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("rotate log file: %w", err)
+	}
+
+	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("reopen log file after rotation: %w", err)
+	}
+
+	w.file = f
+	return nil
+}
+
+func configureLogger(debugFlag bool) io.Closer {
+	level := parseLogLevel(getEnvOrDefault("PLUGIN_LOG_LEVEL", "info"), debugFlag)
+	log.SetLevel(level)
+	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+
+	logPath := getEnvOrDefault("PLUGIN_LOG_PATH", defaultPluginLogPath)
+	writer, err := newCappedFileWriter(logPath, defaultMaxLogSize)
+	if err != nil {
+		log.SetOutput(os.Stderr)
+		log.Warnf("failed to initialize file logging at %s: %v", logPath, err)
+		return nil
+	}
+
+	log.SetOutput(io.MultiWriter(os.Stderr, writer))
+	log.Infof("plugin logging configured with path=%s level=%s max_size_mb=%d", logPath, level.String(), defaultMaxLogSize/(1024*1024))
+	return writer
+}
+
+func parseLogLevel(raw string, debugFlag bool) log.Level {
+	if debugFlag {
+		return log.DebugLevel
+	}
+
+	parsed, err := log.ParseLevel(strings.ToLower(strings.TrimSpace(raw)))
+	if err != nil {
+		return log.InfoLevel
+	}
+	return parsed
+}

--- a/logging.go
+++ b/logging.go
@@ -167,26 +167,6 @@ func parsePluginLogLevel(raw string) log.Level {
 	return parsed
 }
 
-func parseLegacyLogLevel(raw string) log.Level {
-	normalized := strings.TrimSpace(raw)
-	if normalized == "" {
-		return log.DebugLevel
-	}
-
-	numericLevel, err := strconv.Atoi(normalized)
-	if err != nil {
-		log.Errorf("invalid LOG_LEVEL=%q: expected integer 0-6; defaulting to debug", raw)
-		return log.DebugLevel
-	}
-
-	level, err := parseIntegerLogLevel(numericLevel)
-	if err != nil {
-		log.Errorf("invalid LOG_LEVEL=%q: expected integer 0-6; defaulting to debug", raw)
-		return log.DebugLevel
-	}
-	return level
-}
-
 func parseIntegerLogLevel(n int) (log.Level, error) {
 	if n < int(log.PanicLevel) || n > int(log.TraceLevel) {
 		return log.DebugLevel, fmt.Errorf("log level %d outside range 0-6", n)

--- a/logging.go
+++ b/logging.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -13,7 +14,6 @@ import (
 
 const (
 	defaultPluginLogPath = "/run/swarm-external-secrets/plugin.log"
-	defaultPluginLogDir  = "/run/swarm-external-secrets"
 	defaultMaxLogSize    = int64(10 * 1024 * 1024) // 10MB
 )
 
@@ -39,7 +39,7 @@ func newCappedFileWriter(path string, maxBytes int64) (*cappedFileWriter, error)
 		return nil, fmt.Errorf("create log directory: %w", err)
 	}
 
-	// #nosec G304 -- path is constrained to /run/swarm-external-secrets by validateLogPath.
+	// #nosec G304 -- path is the configured plugin log destination after basic path validation.
 	f, err := os.OpenFile(resolvedPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open log file: %w", err)
@@ -84,25 +84,38 @@ func (w *cappedFileWriter) rotateIfNeeded(incoming int64) error {
 
 	rotatedPath := w.path + ".1"
 	if err := os.Remove(rotatedPath); err != nil && !os.IsNotExist(err) {
+		if reopenErr := w.reopenActiveFile(); reopenErr != nil {
+			return fmt.Errorf("remove previous rotated log: %w (reopen active log failed: %v)", err, reopenErr)
+		}
 		return fmt.Errorf("remove previous rotated log: %w", err)
 	}
 
 	if err := os.Rename(w.path, rotatedPath); err != nil && !os.IsNotExist(err) {
+		if reopenErr := w.reopenActiveFile(); reopenErr != nil {
+			return fmt.Errorf("rotate log file: %w (reopen active log failed: %v)", err, reopenErr)
+		}
 		return fmt.Errorf("rotate log file: %w", err)
 	}
 
-	// #nosec G304 -- writer path is validated during construction in newCappedFileWriter.
-	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
+	if err := w.reopenActiveFile(); err != nil {
 		return fmt.Errorf("reopen log file after rotation: %w", err)
 	}
 
+	return nil
+}
+
+func (w *cappedFileWriter) reopenActiveFile() error {
+	// #nosec G304 -- writer path is validated during construction in newCappedFileWriter.
+	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
 	w.file = f
 	return nil
 }
 
 func configureLogger(debugFlag bool) io.Closer {
-	level := parseLogLevel(getEnvOrDefault("PLUGIN_LOG_LEVEL", "info"), debugFlag)
+	level := configuredLogLevel(debugFlag)
 	log.SetLevel(level)
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
 
@@ -119,27 +132,72 @@ func configureLogger(debugFlag bool) io.Closer {
 	return writer
 }
 
-func parseLogLevel(raw string, debugFlag bool) log.Level {
+func configuredLogLevel(debugFlag bool) log.Level {
+	if raw, ok := os.LookupEnv("PLUGIN_LOG_LEVEL"); ok {
+		return parsePluginLogLevel(raw)
+	}
+
+	if raw, ok := os.LookupEnv("LOG_LEVEL"); ok {
+		return parseLegacyLogLevel(raw)
+	}
+
 	if debugFlag {
 		return log.DebugLevel
 	}
 
-	parsed, err := log.ParseLevel(strings.ToLower(strings.TrimSpace(raw)))
+	return log.DebugLevel
+}
+
+func parsePluginLogLevel(raw string) log.Level {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if numericLevel, err := strconv.Atoi(normalized); err == nil {
+		level, err := parseIntegerLogLevel(numericLevel)
+		if err != nil {
+			log.Errorf("invalid PLUGIN_LOG_LEVEL=%q: expected integer 0-6 or log level name; defaulting to debug", raw)
+			return log.DebugLevel
+		}
+		return level
+	}
+
+	parsed, err := log.ParseLevel(normalized)
 	if err != nil {
-		return log.InfoLevel
+		log.Errorf("invalid PLUGIN_LOG_LEVEL=%q: expected integer 0-6 or log level name; defaulting to debug", raw)
+		return log.DebugLevel
 	}
 	return parsed
+}
+
+func parseLegacyLogLevel(raw string) log.Level {
+	normalized := strings.TrimSpace(raw)
+	if normalized == "" {
+		return log.DebugLevel
+	}
+
+	numericLevel, err := strconv.Atoi(normalized)
+	if err != nil {
+		log.Errorf("invalid LOG_LEVEL=%q: expected integer 0-6; defaulting to debug", raw)
+		return log.DebugLevel
+	}
+
+	level, err := parseIntegerLogLevel(numericLevel)
+	if err != nil {
+		log.Errorf("invalid LOG_LEVEL=%q: expected integer 0-6; defaulting to debug", raw)
+		return log.DebugLevel
+	}
+	return level
+}
+
+func parseIntegerLogLevel(n int) (log.Level, error) {
+	if n < int(log.PanicLevel) || n > int(log.TraceLevel) {
+		return log.DebugLevel, fmt.Errorf("log level %d outside range 0-6", n)
+	}
+	return log.Level(n), nil
 }
 
 func validateLogPath(path string) (string, error) {
 	cleanPath := filepath.Clean(strings.TrimSpace(path))
 	if cleanPath == "." || cleanPath == string(filepath.Separator) {
 		return "", fmt.Errorf("invalid log path: %q", path)
-	}
-
-	defaultDir := filepath.Clean(defaultPluginLogDir) + string(filepath.Separator)
-	if !strings.HasPrefix(cleanPath, defaultDir) {
-		return "", fmt.Errorf("log path %q must be under %s", cleanPath, defaultPluginLogDir)
 	}
 
 	return cleanPath, nil

--- a/logging.go
+++ b/logging.go
@@ -137,10 +137,6 @@ func configuredLogLevel(debugFlag bool) log.Level {
 		return parsePluginLogLevel(raw)
 	}
 
-	if raw, ok := os.LookupEnv("LOG_LEVEL"); ok {
-		return parseLegacyLogLevel(raw)
-	}
-
 	if debugFlag {
 		return log.DebugLevel
 	}

--- a/logging.go
+++ b/logging.go
@@ -149,7 +149,7 @@ func parsePluginLogLevel(raw string) log.Level {
 	if numericLevel, err := strconv.Atoi(normalized); err == nil {
 		level, err := parseIntegerLogLevel(numericLevel)
 		if err != nil {
-			log.Errorf("invalidLOG_LEVEL=%q: expected integer 0-6 or log level name; defaulting to debug", raw)
+			log.Errorf("invalid LOG_LEVEL=%q: expected integer 0-6 or log level name; defaulting to debug", raw)
 			return log.DebugLevel
 		}
 		return level

--- a/logging.go
+++ b/logging.go
@@ -133,7 +133,7 @@ func configureLogger(debugFlag bool) io.Closer {
 }
 
 func configuredLogLevel(debugFlag bool) log.Level {
-	if raw, ok := os.LookupEnv("PLUGIN_LOG_LEVEL"); ok {
+	if raw, ok := os.LookupEnv("LOG_LEVEL"); ok {
 		return parsePluginLogLevel(raw)
 	}
 
@@ -149,7 +149,7 @@ func parsePluginLogLevel(raw string) log.Level {
 	if numericLevel, err := strconv.Atoi(normalized); err == nil {
 		level, err := parseIntegerLogLevel(numericLevel)
 		if err != nil {
-			log.Errorf("invalid PLUGIN_LOG_LEVEL=%q: expected integer 0-6 or log level name; defaulting to debug", raw)
+			log.Errorf("invalidLOG_LEVEL=%q: expected integer 0-6 or log level name; defaulting to debug", raw)
 			return log.DebugLevel
 		}
 		return level
@@ -157,7 +157,7 @@ func parsePluginLogLevel(raw string) log.Level {
 
 	parsed, err := log.ParseLevel(normalized)
 	if err != nil {
-		log.Errorf("invalid PLUGIN_LOG_LEVEL=%q: expected integer 0-6 or log level name; defaulting to debug", raw)
+		log.Errorf("invalid LOG_LEVEL=%q: expected integer 0-6 or log level name; defaulting to debug", raw)
 		return log.DebugLevel
 	}
 	return parsed

--- a/main.go
+++ b/main.go
@@ -5,46 +5,11 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/docker/go-plugins-helpers/secrets"
 	log "github.com/sirupsen/logrus"
 )
-
-func configureLogLevel(debugFlag bool) {
-	// Default to InfoLevel; allow override via LOG_LEVEL (0-6) or --debug.
-	log.SetLevel(log.InfoLevel)
-
-	if lvlStr, ok := os.LookupEnv("LOG_LEVEL"); ok {
-		if lvl, err := parseLogLevel(lvlStr); err != nil {
-			log.Warnf("Invalid LOG_LEVEL=%q; expected integer 0-6. Using default level %s.", lvlStr, log.GetLevel())
-		} else {
-			log.SetLevel(lvl)
-			log.Debugf("Log level set from LOG_LEVEL=%s (%s)", strings.TrimSpace(lvlStr), log.GetLevel())
-		}
-		return
-	}
-
-	if debugFlag {
-		log.SetLevel(log.DebugLevel)
-	}
-}
-
-func parseLogLevel(s string) (log.Level, error) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return log.InfoLevel, nil
-	}
-
-	n, err := strconv.Atoi(s)
-	if err != nil || n < 0 || n > 6 {
-		return log.InfoLevel, err
-	}
-
-	return log.Level(n), nil
-}
 
 func main() {
 	var (

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -11,7 +12,6 @@ import (
 )
 
 func main() {
-	log.Print("Starting Vault Secrets Provider...")
 	var (
 		flVersion = flag.Bool("version", false, "Print version")
 		flDebug   = flag.Bool("debug", false, "Enable debug logging")
@@ -22,9 +22,16 @@ func main() {
 		log.Println("Vault Secrets Provider v1.0.0")
 		return
 	}
-	if *flDebug {
-		log.SetLevel(log.DebugLevel)
+	logCloser := configureLogger(*flDebug)
+	if logCloser != nil {
+		defer func(c io.Closer) {
+			if err := c.Close(); err != nil {
+				log.Warnf("Failed to close log file: %v", err)
+			}
+		}(logCloser)
 	}
+
+	log.Print("Starting Vault Secrets Provider...")
 
 	// Initialize the Vault driver
 	driver, err := NewDriver()

--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,13 @@ docker plugin set swarm-external-secrets:latest \
          openbao_field: "secret_key"
    ```
 
+4. Optional: enable plugin log sidecar (for `docker compose logs` visibility):
+   ```bash
+   sudo mkdir -p /run/swarm-external-secrets
+   docker compose -f docker-compose.yml -f docker-compose.logs.yml up -d
+   docker compose -f docker-compose.yml -f docker-compose.logs.yml logs -f secrets-logger
+   ```
+
 | Provider | Status | Authentication | Rotation |
 |----------|--------|---------------|----------|
 | HashiCorp Vault | ✅ Stable | Token, AppRole | ✅ |

--- a/readme.md
+++ b/readme.md
@@ -132,11 +132,25 @@ docker plugin set swarm-external-secrets:latest \
    ```
 
 4. Optional: enable plugin log sidecar (for `docker compose logs` visibility):
+
+   On Linux, the default plugin log path is `/run/swarm-external-secrets/plugin.log`.
+   macOS and Windows filesystems do not support this `/run/**` path by default, so
+   create a writable log directory on the host and point `PLUGIN_LOG_PATH` at it.
+
    ```bash
    sudo mkdir -p /run/swarm-external-secrets
    sudo touch /run/swarm-external-secrets/plugin.log
    docker compose -f docker-compose.yml -f docker-compose.logs.yml up -d
    docker compose -f docker-compose.yml -f docker-compose.logs.yml logs -f secrets-logger
+   ```
+
+   Example for macOS or Windows Docker Desktop:
+
+   ```bash
+   mkdir -p ./logs
+   touch ./logs/plugin.log
+   docker plugin set swarm-external-secrets:latest \
+     PLUGIN_LOG_PATH="$PWD/logs/plugin.log"
    ```
 
 | Provider | Status | Authentication | Rotation |

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,7 @@ docker plugin set swarm-external-secrets:latest \
 4. Optional: enable plugin log sidecar (for `docker compose logs` visibility):
    ```bash
    sudo mkdir -p /run/swarm-external-secrets
+   sudo touch /run/swarm-external-secrets/plugin.log
    docker compose -f docker-compose.yml -f docker-compose.logs.yml up -d
    docker compose -f docker-compose.yml -f docker-compose.logs.yml logs -f secrets-logger
    ```


### PR DESCRIPTION
## Type of change

* [ ] Refactor
* [x] New feature
* [x] Bug fix
* [ ] Optimization
* [ ] Documentation
* [ ] CI

---

## Mention the secrets provider

Vault (tested)

---

## Description

This PR introduces file-based logging with size-based rotation for the plugin, improving observability and debugging. Logs are written to a host-mounted path with configurable location and log level via environment variables. Logging has been standardized using leveled logrus methods (debug, info, warn, error) to reduce noise and improve clarity. A reusable docker-compose.logs.yml sidecar is added to stream logs easily using docker compose logs. The system also includes a safe fallback to stderr if file logging initialization fails.

### Changes

* Added file logging (`/run/swarm-external-secrets/plugin.log`) with rotation (10MB)
* Added env config:
  * `PLUGIN_LOG_PATH`
  * `PLUGIN_LOG_LEVEL`
* Fallback to `stderr` if file logging fails
* Replaced `Printf` with leveled logging (`debug`, `info`, `warn`, `error`)
* Added `docker-compose.logs.yml` with `secrets-logger` sidecar
* Updated docs with debugging + sidecar usage

---

## Commands & Configuration to test

```bash
sudo mkdir -p /run/swarm-external-secrets

docker compose -f docker-compose.yml -f docker-compose.logs.yml up -d
docker compose -f docker-compose.yml -f docker-compose.logs.yml logs -f secrets-logger
```

---

## Screenshots & Logs

n/a

---

## Related Tickets & Documents

* Closes #54 

---
