### PR TITLE
fix: secret rotation prefix matching

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -536,7 +536,6 @@ func buildUpdatedSecretReferences(
 	needsUpdate := false
 	for i, secretRef := range secretRefs {
 		if secretRef == nil {
-			updatedSecrets[i] = nil
 			continue
 		}
 

--- a/driver.go
+++ b/driver.go
@@ -463,7 +463,7 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 	log.Printf("Created new version of secret %s with name %s and ID: %s", secretName, newSecretName, createResponse.ID)
 
 	// Update all services that use this secret to point to the new version
-	if err := d.updateServicesSecretReference(secretName, newSecretName, createResponse.ID); err != nil {
+	if err := d.updateServicesSecretReference(secretName, existingSecret.ID, newSecretName, createResponse.ID); err != nil {
 		// try to remove the new secret since service update failed
 		if cleanupErr := d.dockerClient.SecretRemove(ctx, createResponse.ID); cleanupErr != nil {
 			log.Warnf("failed to remove new secret %s after service update error: %v", createResponse.ID, cleanupErr)
@@ -481,7 +481,7 @@ func (d *SecretsDriver) updateDockerSecret(secretName string, newValue []byte) e
 }
 
 // updateServicesSecretReference updates all services to use the new secret version
-func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretName, newSecretID string) error {
+func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, oldSecretID, newSecretName, newSecretID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -505,6 +505,7 @@ func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretNa
 		needsUpdate := buildUpdatedSecretReferences(
 			containerSpec.Secrets,
 			oldSecretName,
+			oldSecretID,
 			newSecretName,
 			newSecretID,
 			updatedSecrets,
@@ -527,13 +528,19 @@ func (d *SecretsDriver) updateServicesSecretReference(oldSecretName, newSecretNa
 func buildUpdatedSecretReferences(
 	secretRefs []*swarm.SecretReference,
 	oldSecretName string,
+	oldSecretID string,
 	newSecretName string,
 	newSecretID string,
 	updatedSecrets []*swarm.SecretReference,
 ) bool {
 	needsUpdate := false
 	for i, secretRef := range secretRefs {
-		if secretRef.SecretName == oldSecretName || strings.HasPrefix(secretRef.SecretName, oldSecretName+"-") {
+		if secretRef == nil {
+			updatedSecrets[i] = nil
+			continue
+		}
+
+		if (oldSecretID != "" && secretRef.SecretID == oldSecretID) || secretRef.SecretName == oldSecretName {
 			// Update to use the new secret name and ID.
 			updatedSecrets[i] = &swarm.SecretReference{
 				File:       secretRef.File,

--- a/driver_test.go
+++ b/driver_test.go
@@ -8,13 +8,12 @@ import (
 
 func TestBuildUpdatedSecretReferences(t *testing.T) {
 	tests := []struct {
-		name           string
-		ref            *swarm.SecretReference
-		oldSecretID    string
-		newSecretName  string
-		wantUpdate     bool
-		wantSecretID   string
-		wantSecretName string
+		name          string
+		ref           *swarm.SecretReference
+		oldSecretID   string
+		newSecretName string
+		wantUpdate    bool
+		wantRef       *swarm.SecretReference
 	}{
 		{
 			name: "updates exact name",
@@ -22,11 +21,13 @@ func TestBuildUpdatedSecretReferences(t *testing.T) {
 				SecretID:   "old-id",
 				SecretName: "api",
 			},
-			oldSecretID:    "old-id",
-			newSecretName:  "api-123",
-			wantUpdate:     true,
-			wantSecretID:   "new-id",
-			wantSecretName: "api-123",
+			oldSecretID:   "old-id",
+			newSecretName: "api-123",
+			wantUpdate:    true,
+			wantRef: &swarm.SecretReference{
+				SecretID:   "new-id",
+				SecretName: "api-123",
+			},
 		},
 		{
 			name: "updates rotated name with matching ID",
@@ -34,11 +35,13 @@ func TestBuildUpdatedSecretReferences(t *testing.T) {
 				SecretID:   "old-id",
 				SecretName: "api-1111111111111111111",
 			},
-			oldSecretID:    "old-id",
-			newSecretName:  "api-2222222222222222222",
-			wantUpdate:     true,
-			wantSecretID:   "new-id",
-			wantSecretName: "api-2222222222222222222",
+			oldSecretID:   "old-id",
+			newSecretName: "api-2222222222222222222",
+			wantUpdate:    true,
+			wantRef: &swarm.SecretReference{
+				SecretID:   "new-id",
+				SecretName: "api-2222222222222222222",
+			},
 		},
 		{
 			name: "preserves prefix collision",
@@ -70,23 +73,46 @@ func TestBuildUpdatedSecretReferences(t *testing.T) {
 				updatedSecrets,
 			)
 
-			if needsUpdate != tt.wantUpdate {
-				t.Fatalf("needsUpdate = %v, want %v", needsUpdate, tt.wantUpdate)
-			}
-
-			if !tt.wantUpdate {
-				if updatedSecrets[0] != tt.ref {
-					t.Fatal("expected unrelated secret reference to be preserved")
-				}
-				return
-			}
-
-			if updatedSecrets[0].SecretID != tt.wantSecretID {
-				t.Fatalf("SecretID = %q, want %q", updatedSecrets[0].SecretID, tt.wantSecretID)
-			}
-			if updatedSecrets[0].SecretName != tt.wantSecretName {
-				t.Fatalf("SecretName = %q, want %q", updatedSecrets[0].SecretName, tt.wantSecretName)
-			}
+			assertSecretReferenceUpdate(t, needsUpdate, tt.wantUpdate, updatedSecrets[0], tt.ref, tt.wantRef)
 		})
+	}
+}
+
+func assertSecretReferenceUpdate(
+	t *testing.T,
+	gotUpdate bool,
+	wantUpdate bool,
+	gotRef *swarm.SecretReference,
+	originalRef *swarm.SecretReference,
+	wantRef *swarm.SecretReference,
+) {
+	t.Helper()
+
+	if gotUpdate != wantUpdate {
+		t.Fatalf("needsUpdate = %v, want %v", gotUpdate, wantUpdate)
+	}
+	if !wantUpdate {
+		assertSecretReferencePreserved(t, gotRef, originalRef)
+		return
+	}
+	assertSecretReference(t, gotRef, wantRef)
+}
+
+func assertSecretReferencePreserved(t *testing.T, gotRef, originalRef *swarm.SecretReference) {
+	t.Helper()
+
+	if gotRef != originalRef {
+		t.Fatal("expected unrelated secret reference to be preserved")
+	}
+}
+
+func assertSecretReference(t *testing.T, gotRef, wantRef *swarm.SecretReference) {
+	t.Helper()
+
+	if gotRef.SecretID != wantRef.SecretID {
+		t.Fatalf("SecretID = %q, want %q", gotRef.SecretID, wantRef.SecretID)
+	}
+	if gotRef.SecretName != wantRef.SecretName {
+		t.Fatalf("SecretName = %q, want %q", gotRef.SecretName, wantRef.SecretName)
 	}
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+)
+
+func TestBuildUpdatedSecretReferencesUpdatesExactName(t *testing.T) {
+	secretRefs := []*swarm.SecretReference{
+		{
+			SecretID:   "old-id",
+			SecretName: "api",
+		},
+	}
+	updatedSecrets := make([]*swarm.SecretReference, len(secretRefs))
+
+	needsUpdate := buildUpdatedSecretReferences(secretRefs, "api", "old-id", "api-123", "new-id", updatedSecrets)
+
+	if !needsUpdate {
+		t.Fatal("expected exact secret reference to be updated")
+	}
+	if updatedSecrets[0].SecretID != "new-id" {
+		t.Fatalf("expected updated secret ID new-id, got %q", updatedSecrets[0].SecretID)
+	}
+	if updatedSecrets[0].SecretName != "api-123" {
+		t.Fatalf("expected updated secret name api-123, got %q", updatedSecrets[0].SecretName)
+	}
+}
+
+func TestBuildUpdatedSecretReferencesUpdatesMatchingIDForRotatedName(t *testing.T) {
+	secretRefs := []*swarm.SecretReference{
+		{
+			SecretID:   "old-id",
+			SecretName: "api-1111111111111111111",
+		},
+	}
+	updatedSecrets := make([]*swarm.SecretReference, len(secretRefs))
+
+	needsUpdate := buildUpdatedSecretReferences(secretRefs, "api", "old-id", "api-2222222222222222222", "new-id", updatedSecrets)
+
+	if !needsUpdate {
+		t.Fatal("expected rotated secret reference with matching ID to be updated")
+	}
+	if updatedSecrets[0].SecretID != "new-id" {
+		t.Fatalf("expected updated secret ID new-id, got %q", updatedSecrets[0].SecretID)
+	}
+	if updatedSecrets[0].SecretName != "api-2222222222222222222" {
+		t.Fatalf("expected updated secret name api-2222222222222222222, got %q", updatedSecrets[0].SecretName)
+	}
+}
+
+func TestBuildUpdatedSecretReferencesDoesNotUpdatePrefixCollision(t *testing.T) {
+	secretRefs := []*swarm.SecretReference{
+		{
+			SecretID:   "prod-id",
+			SecretName: "api-prod",
+		},
+	}
+	updatedSecrets := make([]*swarm.SecretReference, len(secretRefs))
+
+	needsUpdate := buildUpdatedSecretReferences(secretRefs, "api", "old-id", "api-123", "new-id", updatedSecrets)
+
+	if needsUpdate {
+		t.Fatal("expected unrelated prefix-matching secret reference to be left unchanged")
+	}
+	if updatedSecrets[0] != secretRefs[0] {
+		t.Fatal("expected unrelated secret reference to be preserved")
+	}
+}
+
+func TestBuildUpdatedSecretReferencesDoesNotMatchEmptyOldID(t *testing.T) {
+	secretRefs := []*swarm.SecretReference{
+		{
+			SecretName: "api-prod",
+		},
+	}
+	updatedSecrets := make([]*swarm.SecretReference, len(secretRefs))
+
+	needsUpdate := buildUpdatedSecretReferences(secretRefs, "api", "", "api-123", "new-id", updatedSecrets)
+
+	if needsUpdate {
+		t.Fatal("expected empty old secret ID not to match references with empty IDs")
+	}
+	if updatedSecrets[0] != secretRefs[0] {
+		t.Fatal("expected secret reference to be preserved")
+	}
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -6,83 +6,87 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-func TestBuildUpdatedSecretReferencesUpdatesExactName(t *testing.T) {
-	secretRefs := []*swarm.SecretReference{
+func TestBuildUpdatedSecretReferences(t *testing.T) {
+	tests := []struct {
+		name           string
+		ref            *swarm.SecretReference
+		oldSecretID    string
+		newSecretName  string
+		wantUpdate     bool
+		wantSecretID   string
+		wantSecretName string
+	}{
 		{
-			SecretID:   "old-id",
-			SecretName: "api",
+			name: "updates exact name",
+			ref: &swarm.SecretReference{
+				SecretID:   "old-id",
+				SecretName: "api",
+			},
+			oldSecretID:    "old-id",
+			newSecretName:  "api-123",
+			wantUpdate:     true,
+			wantSecretID:   "new-id",
+			wantSecretName: "api-123",
+		},
+		{
+			name: "updates rotated name with matching ID",
+			ref: &swarm.SecretReference{
+				SecretID:   "old-id",
+				SecretName: "api-1111111111111111111",
+			},
+			oldSecretID:    "old-id",
+			newSecretName:  "api-2222222222222222222",
+			wantUpdate:     true,
+			wantSecretID:   "new-id",
+			wantSecretName: "api-2222222222222222222",
+		},
+		{
+			name: "preserves prefix collision",
+			ref: &swarm.SecretReference{
+				SecretID:   "prod-id",
+				SecretName: "api-prod",
+			},
+			oldSecretID: "old-id",
+		},
+		{
+			name: "does not match empty old ID",
+			ref: &swarm.SecretReference{
+				SecretName: "api-prod",
+			},
 		},
 	}
-	updatedSecrets := make([]*swarm.SecretReference, len(secretRefs))
 
-	needsUpdate := buildUpdatedSecretReferences(secretRefs, "api", "old-id", "api-123", "new-id", updatedSecrets)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secretRefs := []*swarm.SecretReference{tt.ref}
+			updatedSecrets := make([]*swarm.SecretReference, len(secretRefs))
 
-	if !needsUpdate {
-		t.Fatal("expected exact secret reference to be updated")
-	}
-	if updatedSecrets[0].SecretID != "new-id" {
-		t.Fatalf("expected updated secret ID new-id, got %q", updatedSecrets[0].SecretID)
-	}
-	if updatedSecrets[0].SecretName != "api-123" {
-		t.Fatalf("expected updated secret name api-123, got %q", updatedSecrets[0].SecretName)
-	}
-}
+			needsUpdate := buildUpdatedSecretReferences(
+				secretRefs,
+				"api",
+				tt.oldSecretID,
+				tt.newSecretName,
+				"new-id",
+				updatedSecrets,
+			)
 
-func TestBuildUpdatedSecretReferencesUpdatesMatchingIDForRotatedName(t *testing.T) {
-	secretRefs := []*swarm.SecretReference{
-		{
-			SecretID:   "old-id",
-			SecretName: "api-1111111111111111111",
-		},
-	}
-	updatedSecrets := make([]*swarm.SecretReference, len(secretRefs))
+			if needsUpdate != tt.wantUpdate {
+				t.Fatalf("needsUpdate = %v, want %v", needsUpdate, tt.wantUpdate)
+			}
 
-	needsUpdate := buildUpdatedSecretReferences(secretRefs, "api", "old-id", "api-2222222222222222222", "new-id", updatedSecrets)
+			if !tt.wantUpdate {
+				if updatedSecrets[0] != tt.ref {
+					t.Fatal("expected unrelated secret reference to be preserved")
+				}
+				return
+			}
 
-	if !needsUpdate {
-		t.Fatal("expected rotated secret reference with matching ID to be updated")
-	}
-	if updatedSecrets[0].SecretID != "new-id" {
-		t.Fatalf("expected updated secret ID new-id, got %q", updatedSecrets[0].SecretID)
-	}
-	if updatedSecrets[0].SecretName != "api-2222222222222222222" {
-		t.Fatalf("expected updated secret name api-2222222222222222222, got %q", updatedSecrets[0].SecretName)
-	}
-}
-
-func TestBuildUpdatedSecretReferencesDoesNotUpdatePrefixCollision(t *testing.T) {
-	secretRefs := []*swarm.SecretReference{
-		{
-			SecretID:   "prod-id",
-			SecretName: "api-prod",
-		},
-	}
-	updatedSecrets := make([]*swarm.SecretReference, len(secretRefs))
-
-	needsUpdate := buildUpdatedSecretReferences(secretRefs, "api", "old-id", "api-123", "new-id", updatedSecrets)
-
-	if needsUpdate {
-		t.Fatal("expected unrelated prefix-matching secret reference to be left unchanged")
-	}
-	if updatedSecrets[0] != secretRefs[0] {
-		t.Fatal("expected unrelated secret reference to be preserved")
-	}
-}
-
-func TestBuildUpdatedSecretReferencesDoesNotMatchEmptyOldID(t *testing.T) {
-	secretRefs := []*swarm.SecretReference{
-		{
-			SecretName: "api-prod",
-		},
-	}
-	updatedSecrets := make([]*swarm.SecretReference, len(secretRefs))
-
-	needsUpdate := buildUpdatedSecretReferences(secretRefs, "api", "", "api-123", "new-id", updatedSecrets)
-
-	if needsUpdate {
-		t.Fatal("expected empty old secret ID not to match references with empty IDs")
-	}
-	if updatedSecrets[0] != secretRefs[0] {
-		t.Fatal("expected secret reference to be preserved")
+			if updatedSecrets[0].SecretID != tt.wantSecretID {
+				t.Fatalf("SecretID = %q, want %q", updatedSecrets[0].SecretID, tt.wantSecretID)
+			}
+			if updatedSecrets[0].SecretName != tt.wantSecretName {
+				t.Fatalf("SecretName = %q, want %q", updatedSecrets[0].SecretName, tt.wantSecretName)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change 
ex: - [x] Refactor
-->

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Mention the secrets provider

All providers that support rotation. This fix is in the shared Docker Swarm secret rotation path, not in a provider-specific implementation. 

## Description

ixes a secret rotation bug where service secret references were updated when their Docker secret name either matched the rotated secret name exactly or started with `<secretName>-`.

That prefix match could rewrite unrelated secrets with similar names. For example, rotating `api` could also update a service reference to `api-prod`.

The rotation update logic now matches references by:
- the old Docker secret ID, when available
- the exact original Docker secret name

This preserves rotation for the intended secret, including already-rotated secret names when their Docker secret ID matches, while avoiding prefix collisions.

Added regression tests for:
- exact secret name updates
- rotated secret name updates by matching Docker secret ID
- unrelated prefix-matching secrets like `api-prod`
- empty old secret ID handling


## Commands & Configuration to test

```bash
GOCACHE=/tmp/swarm-external-secrets-go-build go test ./...
```

## Screenshots & Logs
N/A
## Related Tickets & Documents

- Related Issue #145 
- Closes #145 
