### PR TITLE
feat: multi-source-secret-payload

### DIFF
--- a/docs/multi-provider.md
+++ b/docs/multi-provider.md
@@ -175,6 +175,31 @@ secrets:
       azure_field: "connection_string"
 ```
 
+### Multiple Sources into One Docker Secret
+
+Use `swarm-external-secrets.sources` when one mounted Docker secret should contain values from multiple external secrets. The label value is a JSON array encoded as a single string, which keeps the Compose file valid and avoids repeated label keys.
+
+```yaml
+secrets:
+  app_credentials:
+    driver: swarm-external-secrets:latest
+    labels:
+      swarm-external-secrets.sources: >-
+        [
+          {"path":"database/mysql","field":"password","key":"MYSQL_PASSWORD"},
+          {"path":"database/postgres","field":"password","key":"POSTGRES_PASSWORD"},
+          {"path":"database/redis","field":"password","key":"REDIS_PASSWORD"}
+        ]
+```
+
+The driver fetches each source from the currently configured provider and renders a JSON object by default:
+
+```json
+{"MYSQL_PASSWORD":"...","POSTGRES_PASSWORD":"...","REDIS_PASSWORD":"..."}
+```
+
+For an env-file style payload, set `swarm-external-secrets.format: "env"`.
+
 ## Multiple Providers in the Same Swarm Cluster
 
 For production isolation, run one provider per plugin instance (unique plugin name) and reference each instance as a separate secret driver.

--- a/driver.go
+++ b/driver.go
@@ -215,7 +215,7 @@ func (d *SecretsDriver) getAggregatedSecret(ctx context.Context, req secrets.Req
 
 		value, err := d.provider.GetSecret(ctx, sourceReq)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get source %q: %v", source.Key, err)
+			return nil, fmt.Errorf("failed to get source %q (path %q): %w", source.Key, source.Path, err)
 		}
 		values[source.Key] = string(value)
 	}
@@ -332,13 +332,52 @@ func renderAggregatedSecret(values map[string]string, format string) ([]byte, er
 
 		lines := make([]string, 0, len(values))
 		for _, key := range keys {
+			if !isValidEnvKey(key) {
+				return nil, fmt.Errorf("invalid env key %q: must match [A-Z_][A-Z0-9_]*", key)
+			}
 			value := values[key]
+			value = escapeEnvValue(value)
 			lines = append(lines, fmt.Sprintf("%s=%s", key, value))
 		}
 		return []byte(strings.Join(lines, "\n") + "\n"), nil
 	default:
 		return nil, fmt.Errorf("unsupported aggregated secret format %q", format)
 	}
+}
+
+func isValidEnvKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	first := key[0]
+	if !((first >= 'A' && first <= 'Z') || first == '_') {
+		return false
+	}
+	for _, c := range key {
+		if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func escapeEnvValue(value string) string {
+	result := make([]rune, 0, len(value))
+	for _, c := range value {
+		switch c {
+		case '\\':
+			result = append(result, '\\', '\\')
+		case '\n':
+			result = append(result, '\\', 'n')
+		case '\r':
+			result = append(result, '\\', 'r')
+		case '"':
+			result = append(result, '\\', '"')
+		default:
+			result = append(result, c)
+		}
+	}
+	return string(result)
 }
 
 // shouldNotReuse returns the value for secrets.Response.DoNotReuse.

--- a/driver.go
+++ b/driver.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -21,7 +23,18 @@ import (
 const (
 	kvV2PathFormat        = "secret/data/%s"
 	kvV2ServicePathFormat = "secret/data/%s/%s"
+	secretSourcesLabel    = "swarm-external-secrets.sources"
+	secretSourcesLabelAlt = "secret_sources"
+	secretFormatLabel     = "swarm-external-secrets.format"
+	secretFormatLabelAlt  = "secret_format"
 )
+
+type secretSource struct {
+	Provider string `json:"provider,omitempty"`
+	Path     string `json:"path"`
+	Field    string `json:"field,omitempty"`
+	Key      string `json:"key"`
+}
 
 // SecretsDriver implements the secrets.Driver interface with multi-provider support
 type SecretsDriver struct {
@@ -143,8 +156,7 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Get secret from the provider
-	value, err := d.provider.GetSecret(ctx, req)
+	value, err := d.getSecretValue(ctx, req)
 	if err != nil {
 		log.Printf("Error getting secret from provider: %v", err)
 		return secrets.Response{
@@ -167,6 +179,185 @@ func (d *SecretsDriver) Get(req secrets.Request) secrets.Response {
 	return secrets.Response{
 		Value:      value,
 		DoNotReuse: doNotReuse,
+	}
+}
+
+func (d *SecretsDriver) getSecretValue(ctx context.Context, req secrets.Request) ([]byte, error) {
+	if _, exists := getSecretSourcesSpec(req.SecretLabels); exists {
+		return d.getAggregatedSecret(ctx, req)
+	}
+	return d.provider.GetSecret(ctx, req)
+}
+
+func getSecretSourcesSpec(labels map[string]string) (string, bool) {
+	if labels == nil {
+		return "", false
+	}
+	if spec, exists := labels[secretSourcesLabel]; exists {
+		return spec, true
+	}
+	if spec, exists := labels[secretSourcesLabelAlt]; exists {
+		return spec, true
+	}
+	return "", false
+}
+
+func (d *SecretsDriver) getAggregatedSecret(ctx context.Context, req secrets.Request) ([]byte, error) {
+	sources, err := parseSecretSources(req.SecretLabels, d.provider.GetProviderName())
+	if err != nil {
+		return nil, err
+	}
+
+	values := make(map[string]string, len(sources))
+	for _, source := range sources {
+		sourceReq := req
+		sourceReq.SecretLabels = labelsForSecretSource(req.SecretLabels, d.provider.GetProviderName(), source)
+
+		value, err := d.provider.GetSecret(ctx, sourceReq)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get source %q: %v", source.Key, err)
+		}
+		values[source.Key] = string(value)
+	}
+
+	return renderAggregatedSecret(values, getSecretFormat(req.SecretLabels))
+}
+
+func parseSecretSources(labels map[string]string, currentProvider string) ([]secretSource, error) {
+	spec, exists := getSecretSourcesSpec(labels)
+	if !exists {
+		return nil, fmt.Errorf("%s label is required", secretSourcesLabel)
+	}
+
+	var sources []secretSource
+	if err := json.Unmarshal([]byte(spec), &sources); err != nil {
+		return nil, fmt.Errorf("invalid %s JSON: %v", secretSourcesLabel, err)
+	}
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("%s must contain at least one source", secretSourcesLabel)
+	}
+
+	seenKeys := make(map[string]struct{}, len(sources))
+	for i := range sources {
+		sources[i].Provider = strings.TrimSpace(sources[i].Provider)
+		sources[i].Path = strings.TrimSpace(sources[i].Path)
+		sources[i].Field = strings.TrimSpace(sources[i].Field)
+		sources[i].Key = strings.TrimSpace(sources[i].Key)
+
+		if sources[i].Path == "" {
+			return nil, fmt.Errorf("source %d path is required", i)
+		}
+		if sources[i].Key == "" {
+			return nil, fmt.Errorf("source %d key is required", i)
+		}
+		if sources[i].Provider != "" && !providerMatches(currentProvider, sources[i].Provider) {
+			return nil, fmt.Errorf("source %d provider %q does not match configured provider %q", i, sources[i].Provider, currentProvider)
+		}
+		if _, exists := seenKeys[sources[i].Key]; exists {
+			return nil, fmt.Errorf("duplicate source key %q", sources[i].Key)
+		}
+		seenKeys[sources[i].Key] = struct{}{}
+	}
+
+	return sources, nil
+}
+
+func providerMatches(currentProvider, requestedProvider string) bool {
+	currentProvider = strings.ToLower(strings.TrimSpace(currentProvider))
+	requestedProvider = strings.ToLower(strings.TrimSpace(requestedProvider))
+
+	switch currentProvider {
+	case "vault":
+		return requestedProvider == "vault" || requestedProvider == "hashicorp-vault"
+	case "aws":
+		return requestedProvider == "aws" || requestedProvider == "aws-secrets-manager"
+	case "gcp":
+		return requestedProvider == "gcp" || requestedProvider == "gcp-secret-manager" || requestedProvider == "google"
+	case "azure":
+		return requestedProvider == "azure" || requestedProvider == "azure-key-vault"
+	case "openbao":
+		return requestedProvider == "openbao"
+	default:
+		return requestedProvider == currentProvider
+	}
+}
+
+func labelsForSecretSource(baseLabels map[string]string, providerName string, source secretSource) map[string]string {
+	labels := copyStringMap(baseLabels)
+	delete(labels, secretSourcesLabel)
+	delete(labels, secretSourcesLabelAlt)
+	delete(labels, secretFormatLabel)
+	delete(labels, secretFormatLabelAlt)
+
+	switch providerName {
+	case "vault":
+		labels["vault_path"] = source.Path
+		setOrDelete(labels, "vault_field", source.Field)
+	case "aws":
+		labels["aws_secret_name"] = source.Path
+		setOrDelete(labels, "aws_field", source.Field)
+	case "gcp":
+		labels["gcp_secret_name"] = source.Path
+		setOrDelete(labels, "gcp_field", source.Field)
+	case "azure":
+		labels["azure_secret_name"] = source.Path
+		setOrDelete(labels, "azure_field", source.Field)
+	case "openbao":
+		labels["openbao_path"] = source.Path
+		setOrDelete(labels, "openbao_field", source.Field)
+	}
+
+	return labels
+}
+
+func setOrDelete(labels map[string]string, key, value string) {
+	if value == "" {
+		delete(labels, key)
+		return
+	}
+	labels[key] = value
+}
+
+func copyStringMap(values map[string]string) map[string]string {
+	copied := make(map[string]string, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
+}
+
+func getSecretFormat(labels map[string]string) string {
+	if labels == nil {
+		return "json"
+	}
+	if format := strings.TrimSpace(labels[secretFormatLabel]); format != "" {
+		return strings.ToLower(format)
+	}
+	if format := strings.TrimSpace(labels[secretFormatLabelAlt]); format != "" {
+		return strings.ToLower(format)
+	}
+	return "json"
+}
+
+func renderAggregatedSecret(values map[string]string, format string) ([]byte, error) {
+	switch format {
+	case "", "json":
+		return json.Marshal(values)
+	case "env":
+		keys := make([]string, 0, len(values))
+		for key := range values {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		lines := make([]string, 0, len(values))
+		for _, key := range keys {
+			value := values[key]
+			lines = append(lines, fmt.Sprintf("%s=%s", key, value))
+		}
+		return []byte(strings.Join(lines, "\n") + "\n"), nil
+	default:
+		return nil, fmt.Errorf("unsupported aggregated secret format %q", format)
 	}
 }
 
@@ -246,6 +437,8 @@ func (d *SecretsDriver) trackSecret(req secrets.Request, value []byte) {
 		DockerSecretName: req.SecretName,
 		SecretPath:       secretPath,
 		SecretField:      secretField,
+		SecretLabels:     copyStringMap(req.SecretLabels),
+		ServiceName:      req.ServiceName,
 		ServiceNames:     []string{req.ServiceName}, // Start with current service
 		LastHash:         hash,
 		LastUpdated:      time.Now(),
@@ -356,6 +549,21 @@ func (d *SecretsDriver) hasSecretChanged(secretInfo *providers.SecretInfo) bool 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	if _, exists := getSecretSourcesSpec(secretInfo.SecretLabels); exists {
+		req := secrets.Request{
+			SecretName:   secretInfo.DockerSecretName,
+			ServiceName:  secretInfo.ServiceName,
+			SecretLabels: copyStringMap(secretInfo.SecretLabels),
+		}
+		value, err := d.getAggregatedSecret(ctx, req)
+		if err != nil {
+			log.Errorf("Error checking aggregated secret change for %s: %v", secretInfo.DockerSecretName, err)
+			return false
+		}
+		currentHash := fmt.Sprintf("%x", sha256.Sum256(value))
+		return currentHash != secretInfo.LastHash
+	}
+
 	changed, err := d.provider.CheckSecretChanged(ctx, secretInfo)
 	if err != nil {
 		log.Errorf("Error checking secret change for %s: %v", secretInfo.DockerSecretName, err)
@@ -373,33 +581,38 @@ func (d *SecretsDriver) rotateSecret(secretInfo *providers.SecretInfo) error {
 	req := secrets.Request{
 		SecretName:   secretInfo.DockerSecretName,
 		SecretLabels: make(map[string]string),
+		ServiceName:  secretInfo.ServiceName,
 	}
 
-	// Set appropriate field and path labels based on provider
-	switch secretInfo.Provider {
-	case "vault":
-		req.SecretLabels["vault_field"] = secretInfo.SecretField
-		// Extract the specific path part from the full path
-		req.SecretLabels["vault_path"] = strings.TrimPrefix(secretInfo.SecretPath, "secret/data/")
-	case "aws":
-		req.SecretLabels["aws_field"] = secretInfo.SecretField
-		req.SecretLabels["aws_secret_name"] = secretInfo.SecretPath
-	case "gcp":
-		req.SecretLabels["gcp_field"] = secretInfo.SecretField
-		req.SecretLabels["gcp_secret_name"] = secretInfo.SecretPath
-	case "azure":
-		req.SecretLabels["azure_field"] = secretInfo.SecretField
-		req.SecretLabels["azure_secret_name"] = secretInfo.SecretPath
-	case "openbao":
-		req.SecretLabels["openbao_field"] = secretInfo.SecretField
-		req.SecretLabels["openbao_path"] = strings.TrimPrefix(secretInfo.SecretPath, "secret/data/")
+	if len(secretInfo.SecretLabels) > 0 {
+		req.SecretLabels = copyStringMap(secretInfo.SecretLabels)
+	} else {
+		// Set appropriate field and path labels based on provider
+		switch secretInfo.Provider {
+		case "vault":
+			req.SecretLabels["vault_field"] = secretInfo.SecretField
+			// Extract the specific path part from the full path
+			req.SecretLabels["vault_path"] = strings.TrimPrefix(secretInfo.SecretPath, "secret/data/")
+		case "aws":
+			req.SecretLabels["aws_field"] = secretInfo.SecretField
+			req.SecretLabels["aws_secret_name"] = secretInfo.SecretPath
+		case "gcp":
+			req.SecretLabels["gcp_field"] = secretInfo.SecretField
+			req.SecretLabels["gcp_secret_name"] = secretInfo.SecretPath
+		case "azure":
+			req.SecretLabels["azure_field"] = secretInfo.SecretField
+			req.SecretLabels["azure_secret_name"] = secretInfo.SecretPath
+		case "openbao":
+			req.SecretLabels["openbao_field"] = secretInfo.SecretField
+			req.SecretLabels["openbao_path"] = strings.TrimPrefix(secretInfo.SecretPath, "secret/data/")
+		}
 	}
 
 	// Get the new secret value from the provider
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	newValue, err := d.provider.GetSecret(ctx, req)
+	newValue, err := d.getSecretValue(ctx, req)
 	if err != nil {
 		return fmt.Errorf("failed to get updated secret from provider: %v", err)
 	}

--- a/driver.go
+++ b/driver.go
@@ -350,11 +350,11 @@ func isValidEnvKey(key string) bool {
 		return false
 	}
 	first := key[0]
-	if !((first >= 'A' && first <= 'Z') || first == '_') {
+	if (first < 'A' || first > 'Z') && first != '_' {
 		return false
 	}
 	for _, c := range key {
-		if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' {
 			return false
 		}
 	}

--- a/driver.go
+++ b/driver.go
@@ -203,7 +203,7 @@ func getSecretSourcesSpec(labels map[string]string) (string, bool) {
 }
 
 func (d *SecretsDriver) getAggregatedSecret(ctx context.Context, req secrets.Request) ([]byte, error) {
-	sources, err := parseSecretSources(req.SecretLabels, d.provider.GetProviderName())
+	sources, err := parseSecretSources(req.SecretLabels, d.provider)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (d *SecretsDriver) getAggregatedSecret(ctx context.Context, req secrets.Req
 	return renderAggregatedSecret(values, getSecretFormat(req.SecretLabels))
 }
 
-func parseSecretSources(labels map[string]string, currentProvider string) ([]secretSource, error) {
+func parseSecretSources(labels map[string]string, provider providers.SecretsProvider) ([]secretSource, error) {
 	spec, exists := getSecretSourcesSpec(labels)
 	if !exists {
 		return nil, fmt.Errorf("%s label is required", secretSourcesLabel)
@@ -250,8 +250,8 @@ func parseSecretSources(labels map[string]string, currentProvider string) ([]sec
 		if sources[i].Key == "" {
 			return nil, fmt.Errorf("source %d key is required", i)
 		}
-		if sources[i].Provider != "" && !providerMatches(currentProvider, sources[i].Provider) {
-			return nil, fmt.Errorf("source %d provider %q does not match configured provider %q", i, sources[i].Provider, currentProvider)
+		if sources[i].Provider != "" && !provider.Matches(sources[i].Provider) {
+			return nil, fmt.Errorf("source %d provider %q does not match", i, sources[i].Provider)
 		}
 		if _, exists := seenKeys[sources[i].Key]; exists {
 			return nil, fmt.Errorf("duplicate source key %q", sources[i].Key)
@@ -260,26 +260,6 @@ func parseSecretSources(labels map[string]string, currentProvider string) ([]sec
 	}
 
 	return sources, nil
-}
-
-func providerMatches(currentProvider, requestedProvider string) bool {
-	currentProvider = strings.ToLower(strings.TrimSpace(currentProvider))
-	requestedProvider = strings.ToLower(strings.TrimSpace(requestedProvider))
-
-	switch currentProvider {
-	case "vault":
-		return requestedProvider == "vault" || requestedProvider == "hashicorp-vault"
-	case "aws":
-		return requestedProvider == "aws" || requestedProvider == "aws-secrets-manager"
-	case "gcp":
-		return requestedProvider == "gcp" || requestedProvider == "gcp-secret-manager" || requestedProvider == "google"
-	case "azure":
-		return requestedProvider == "azure" || requestedProvider == "azure-key-vault"
-	case "openbao":
-		return requestedProvider == "openbao"
-	default:
-		return requestedProvider == currentProvider
-	}
 }
 
 func labelsForSecretSource(baseLabels map[string]string, providerName string, source secretSource) map[string]string {

--- a/driver_test.go
+++ b/driver_test.go
@@ -172,6 +172,69 @@ func TestGetAggregatedSecretEnvFormat(t *testing.T) {
 	}
 }
 
+func TestGetAggregatedSecretRejectsUnsupportedFormat(t *testing.T) {
+	provider := &fakeProvider{
+		name: "vault",
+		secrets: map[string]map[string]string{
+			"prod/api": {"token": "abc"},
+		},
+	}
+	driver := &SecretsDriver{provider: provider}
+	_, err := driver.getAggregatedSecret(context.Background(), secrets.Request{
+		SecretName: "app_credentials",
+		SecretLabels: map[string]string{
+			secretSourcesLabel: `[{"path":"prod/api","field":"token","key":"API_TOKEN"}]`,
+			secretFormatLabel:  "xml",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected unsupported format error")
+	}
+}
+
+func TestRenderAggregatedSecretEnvRejectsInvalidKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "starts with number", key: "1KEY"},
+		{name: "contains dash", key: "MY-KEY"},
+		{name: "contains dot", key: "MY.KEY"},
+		{name: "lowercase", key: "my_key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := renderAggregatedSecret(map[string]string{tt.key: "value"}, "env")
+			if err == nil {
+				t.Fatalf("expected error for invalid key %q", tt.key)
+			}
+		})
+	}
+}
+
+func TestRenderAggregatedSecretEnvEscapesValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantEsc string
+	}{
+		{name: "newline", value: "hello\nworld", wantEsc: "hello\\nworld"},
+		{name: "backslash", value: "path\\to\\file", wantEsc: "path\\\\to\\\\file"},
+		{name: "carriage return", value: "hello\rworld", wantEsc: "hello\\rworld"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := renderAggregatedSecret(map[string]string{"KEY": tt.value}, "env")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(string(out), tt.wantEsc) {
+				t.Fatalf("expected escaped value %q in output %q", tt.wantEsc, string(out))
+			}
+		})
+	}
+}
+
 func TestParseSecretSourcesRejectsDifferentProvider(t *testing.T) {
 	provider := &fakeProvider{name: "vault"}
 	_, err := parseSecretSources(map[string]string{
@@ -179,6 +242,56 @@ func TestParseSecretSourcesRejectsDifferentProvider(t *testing.T) {
 	}, provider)
 	if err == nil {
 		t.Fatal("expected provider mismatch error")
+	}
+}
+
+func TestParseSecretSourcesRejectsInvalidJSON(t *testing.T) {
+	provider := &fakeProvider{name: "vault"}
+	_, err := parseSecretSources(map[string]string{
+		secretSourcesLabel: `[{"path":"prod/db","field":"password","key":"DB_PASSWORD"`,
+	}, provider)
+	if err == nil {
+		t.Fatal("expected invalid JSON error")
+	}
+}
+
+func TestParseSecretSourcesRejectsMissingRequiredFields(t *testing.T) {
+	provider := &fakeProvider{name: "vault"}
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "missing path",
+			source: `[{"field":"password","key":"DB_PASSWORD"}]`,
+		},
+		{
+			name:   "missing key",
+			source: `[{"path":"prod/db","field":"password"}]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseSecretSources(map[string]string{
+				secretSourcesLabel: tt.source,
+			}, provider)
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestParseSecretSourcesRejectsDuplicateKey(t *testing.T) {
+	provider := &fakeProvider{name: "vault"}
+	_, err := parseSecretSources(map[string]string{
+		secretSourcesLabel: `[
+			{"path":"prod/api","field":"token","key":"APP_SECRET"},
+			{"path":"prod/db","field":"password","key":"APP_SECRET"}
+		]`,
+	}, provider)
+	if err == nil {
+		t.Fatal("expected duplicate key error")
 	}
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,10 +1,234 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/go-plugins-helpers/secrets"
+
+	"github.com/sugar-org/vault-swarm-plugin/providers"
 )
+
+type fakeProvider struct {
+	name     string
+	secrets  map[string]map[string]string
+	requests []secrets.Request
+}
+
+func (f *fakeProvider) Initialize(config map[string]string) error {
+	return nil
+}
+
+func (f *fakeProvider) GetSecret(ctx context.Context, req secrets.Request) ([]byte, error) {
+	f.requests = append(f.requests, req)
+
+	path := providerPathFromLabels(req.SecretLabels, f.name)
+	field := providerFieldFromLabels(req.SecretLabels, f.name)
+	if field == "" {
+		field = "value"
+	}
+
+	fields, exists := f.secrets[path]
+	if !exists {
+		return nil, fmt.Errorf("missing path %s", path)
+	}
+	value, exists := fields[field]
+	if !exists {
+		return nil, fmt.Errorf("missing field %s", field)
+	}
+	return []byte(value), nil
+}
+
+func (f *fakeProvider) SupportsRotation() bool {
+	return true
+}
+
+func (f *fakeProvider) CheckSecretChanged(ctx context.Context, secretInfo *providers.SecretInfo) (bool, error) {
+	return false, nil
+}
+
+func (f *fakeProvider) GetProviderName() string {
+	return f.name
+}
+
+func (f *fakeProvider) Close() error {
+	return nil
+}
+
+func providerPathFromLabels(labels map[string]string, providerName string) string {
+	switch providerName {
+	case "vault":
+		return labels["vault_path"]
+	case "aws":
+		return labels["aws_secret_name"]
+	case "gcp":
+		return labels["gcp_secret_name"]
+	case "azure":
+		return labels["azure_secret_name"]
+	case "openbao":
+		return labels["openbao_path"]
+	default:
+		return ""
+	}
+}
+
+func providerFieldFromLabels(labels map[string]string, providerName string) string {
+	switch providerName {
+	case "vault":
+		return labels["vault_field"]
+	case "aws":
+		return labels["aws_field"]
+	case "gcp":
+		return labels["gcp_field"]
+	case "azure":
+		return labels["azure_field"]
+	case "openbao":
+		return labels["openbao_field"]
+	default:
+		return ""
+	}
+}
+
+func TestGetAggregatedSecretJSON(t *testing.T) {
+	provider := &fakeProvider{
+		name: "vault",
+		secrets: map[string]map[string]string{
+			"database/mysql":    {"password": "mysql-pass"},
+			"database/postgres": {"password": "pg-pass"},
+		},
+	}
+	driver := &SecretsDriver{provider: provider}
+
+	value, err := driver.getAggregatedSecret(context.Background(), secrets.Request{
+		SecretName: "app_credentials",
+		SecretLabels: map[string]string{
+			secretSourcesLabel: `[
+				{"path":"database/mysql","field":"password","key":"MYSQL_PASSWORD"},
+				{"path":"database/postgres","field":"password","key":"POSTGRES_PASSWORD"}
+			]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("getAggregatedSecret returned error: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(value, &got); err != nil {
+		t.Fatalf("aggregated secret is not JSON: %v", err)
+	}
+
+	want := map[string]string{
+		"MYSQL_PASSWORD":    "mysql-pass",
+		"POSTGRES_PASSWORD": "pg-pass",
+	}
+	assertStringMap(t, got, want)
+
+	if len(provider.requests) != 2 {
+		t.Fatalf("provider requests = %d, want 2", len(provider.requests))
+	}
+	if provider.requests[0].SecretLabels["vault_path"] != "database/mysql" {
+		t.Fatalf("first vault_path = %q, want database/mysql", provider.requests[0].SecretLabels["vault_path"])
+	}
+	if provider.requests[1].SecretLabels["vault_field"] != "password" {
+		t.Fatalf("second vault_field = %q, want password", provider.requests[1].SecretLabels["vault_field"])
+	}
+}
+
+func TestGetAggregatedSecretEnvFormat(t *testing.T) {
+	provider := &fakeProvider{
+		name: "aws",
+		secrets: map[string]map[string]string{
+			"prod/api": {"token": "abc"},
+			"prod/db":  {"password": "xyz"},
+		},
+	}
+	driver := &SecretsDriver{provider: provider}
+
+	value, err := driver.getAggregatedSecret(context.Background(), secrets.Request{
+		SecretName: "app_credentials",
+		SecretLabels: map[string]string{
+			secretSourcesLabel: `[
+				{"path":"prod/api","field":"token","key":"API_TOKEN"},
+				{"path":"prod/db","field":"password","key":"DB_PASSWORD"}
+			]`,
+			secretFormatLabel: "env",
+		},
+	})
+	if err != nil {
+		t.Fatalf("getAggregatedSecret returned error: %v", err)
+	}
+
+	want := "API_TOKEN=abc\nDB_PASSWORD=xyz\n"
+	if string(value) != want {
+		t.Fatalf("aggregated env payload = %q, want %q", string(value), want)
+	}
+}
+
+func TestParseSecretSourcesRejectsDifferentProvider(t *testing.T) {
+	_, err := parseSecretSources(map[string]string{
+		secretSourcesLabel: `[{"provider":"aws","path":"prod/db","field":"password","key":"DB_PASSWORD"}]`,
+	}, "vault")
+	if err == nil {
+		t.Fatal("expected provider mismatch error")
+	}
+}
+
+func TestLabelsForSecretSourceAllProviders(t *testing.T) {
+	tests := []struct {
+		provider  string
+		pathLabel string
+		fieldKey  string
+	}{
+		{provider: "vault", pathLabel: "vault_path", fieldKey: "vault_field"},
+		{provider: "aws", pathLabel: "aws_secret_name", fieldKey: "aws_field"},
+		{provider: "gcp", pathLabel: "gcp_secret_name", fieldKey: "gcp_field"},
+		{provider: "azure", pathLabel: "azure_secret_name", fieldKey: "azure_field"},
+		{provider: "openbao", pathLabel: "openbao_path", fieldKey: "openbao_field"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			labels := labelsForSecretSource(map[string]string{
+				secretSourcesLabel: "[]",
+				secretFormatLabel:  "json",
+				"secret_reuse":     "true",
+			}, tt.provider, secretSource{
+				Path:  "app/path",
+				Field: "password",
+				Key:   "APP_PASSWORD",
+			})
+
+			if labels[tt.pathLabel] != "app/path" {
+				t.Fatalf("%s = %q, want app/path", tt.pathLabel, labels[tt.pathLabel])
+			}
+			if labels[tt.fieldKey] != "password" {
+				t.Fatalf("%s = %q, want password", tt.fieldKey, labels[tt.fieldKey])
+			}
+			if _, exists := labels[secretSourcesLabel]; exists {
+				t.Fatalf("%s should not be forwarded to provider request", secretSourcesLabel)
+			}
+			if labels["secret_reuse"] != "true" {
+				t.Fatal("expected unrelated labels to be preserved")
+			}
+		})
+	}
+}
+
+func assertStringMap(t *testing.T, got, want map[string]string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("map length = %d, want %d", len(got), len(want))
+	}
+	for key, wantValue := range want {
+		if got[key] != wantValue {
+			t.Fatalf("%s = %q, want %q", key, got[key], wantValue)
+		}
+	}
+}
 
 func TestBuildUpdatedSecretReferences(t *testing.T) {
 	tests := []struct {

--- a/driver_test.go
+++ b/driver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
@@ -52,6 +53,10 @@ func (f *fakeProvider) CheckSecretChanged(ctx context.Context, secretInfo *provi
 
 func (f *fakeProvider) GetProviderName() string {
 	return f.name
+}
+
+func (f *fakeProvider) Matches(requested string) bool {
+	return strings.EqualFold(requested, f.name)
 }
 
 func (f *fakeProvider) Close() error {
@@ -168,9 +173,10 @@ func TestGetAggregatedSecretEnvFormat(t *testing.T) {
 }
 
 func TestParseSecretSourcesRejectsDifferentProvider(t *testing.T) {
+	provider := &fakeProvider{name: "vault"}
 	_, err := parseSecretSources(map[string]string{
 		secretSourcesLabel: `[{"provider":"aws","path":"prod/db","field":"password","key":"DB_PASSWORD"}]`,
-	}, "vault")
+	}, provider)
 	if err == nil {
 		t.Fatal("expected provider mismatch error")
 	}

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -120,6 +121,12 @@ func (a *AWSProvider) CheckSecretChanged(ctx context.Context, secretInfo *Secret
 // GetProviderName returns the name of this provider
 func (a *AWSProvider) GetProviderName() string {
 	return "aws"
+}
+
+// Matches checks if this provider matches the given provider identifier
+func (a *AWSProvider) Matches(requested string) bool {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	return requested == "aws" || requested == "aws-secrets-manager"
 }
 
 // Close performs cleanup for the AWS provider

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -107,6 +107,12 @@ func (az *AzureProvider) GetProviderName() string {
 	return "azure"
 }
 
+// Matches checks if this provider matches the given provider identifier
+func (az *AzureProvider) Matches(requested string) bool {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	return requested == "azure" || requested == "azure-key-vault"
+}
+
 // CheckSecretChanged checks if a secret's value has changed in Azure Key Vault.
 func (az *AzureProvider) CheckSecretChanged(ctx context.Context, secretInfo *SecretInfo) (bool, error) {
 	resp, err := az.client.GetSecret(ctx, secretInfo.SecretPath, "", nil)

--- a/providers/gcp.go
+++ b/providers/gcp.go
@@ -251,6 +251,12 @@ func (g *GCPProvider) GetProviderName() string {
 	return "gcp"
 }
 
+// Matches checks if this provider matches the given provider identifier
+func (g *GCPProvider) Matches(requested string) bool {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	return requested == "gcp" || requested == "gcp-secret-manager" || requested == "google"
+}
+
 // Close performs cleanup for the GCP provider
 func (g *GCPProvider) Close() error {
 	if g.client != nil {

--- a/providers/interface.go
+++ b/providers/interface.go
@@ -37,6 +37,9 @@ type SecretsProvider interface {
 	// GetProviderName returns the name of this provider
 	GetProviderName() string
 
+	// Matches checks if this provider matches the given provider identifier
+	Matches(requested string) bool
+
 	// Close performs any cleanup needed by the provider
 	Close() error
 }

--- a/providers/interface.go
+++ b/providers/interface.go
@@ -12,6 +12,8 @@ type SecretInfo struct {
 	DockerSecretName string
 	SecretPath       string
 	SecretField      string
+	SecretLabels     map[string]string
+	ServiceName      string
 	ServiceNames     []string
 	LastHash         string // Hash of the secret value for change detection
 	LastUpdated      time.Time

--- a/providers/openbao.go
+++ b/providers/openbao.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"strings"
 
 	"github.com/docker/go-plugins-helpers/secrets"
 	"github.com/openbao/openbao/api/v2"
@@ -145,6 +146,12 @@ func (o *OpenBaoProvider) CheckSecretChanged(ctx context.Context, secretInfo *Se
 // GetProviderName returns the name of this provider
 func (o *OpenBaoProvider) GetProviderName() string {
 	return "openbao"
+}
+
+// Matches checks if this provider matches the given provider identifier
+func (o *OpenBaoProvider) Matches(requested string) bool {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	return requested == "openbao"
 }
 
 // Close performs cleanup for the OpenBao provider

--- a/providers/vault.go
+++ b/providers/vault.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/docker/go-plugins-helpers/secrets"
 	"github.com/hashicorp/vault/api"
@@ -145,6 +146,12 @@ func (v *VaultProvider) CheckSecretChanged(ctx context.Context, secretInfo *Secr
 // GetProviderName returns the name of this provider
 func (v *VaultProvider) GetProviderName() string {
 	return "vault"
+}
+
+// Matches checks if this provider matches the given provider identifier
+func (v *VaultProvider) Matches(requested string) bool {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	return requested == "vault" || requested == "hashicorp-vault"
 }
 
 // Close performs cleanup for the Vault provider

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,23 @@ docker plugin set swarm-external-secrets:latest \
          openbao_field: "secret_key"
    ```
 
+   **Multiple external secrets into one Docker secret:**
+   ```yaml
+   secrets:
+     app_credentials:
+       driver: swarm-external-secrets:latest
+       labels:
+         swarm-external-secrets.sources: >-
+           [
+             {"path":"database/mysql","field":"password","key":"MYSQL_PASSWORD"},
+             {"path":"database/postgres","field":"password","key":"POSTGRES_PASSWORD"},
+             {"path":"database/redis","field":"password","key":"REDIS_PASSWORD"}
+           ]
+   ```
+
+   The driver fetches each source from the currently configured provider and returns one JSON object by default:
+   `{"MYSQL_PASSWORD":"...","POSTGRES_PASSWORD":"...","REDIS_PASSWORD":"..."}`.
+
 | Provider | Status | Authentication | Rotation |
 |----------|--------|---------------|----------|
 | HashiCorp Vault | ✅ Stable | Token, AppRole | ✅ |

--- a/scripts/tests/smoke-multi-source-compose.yml
+++ b/scripts/tests/smoke-multi-source-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+  app:
+    image: busybox:latest
+    command: >
+      sh -c "
+        while true; do
+          echo 'Current aggregated secret:' && cat /run/secrets/app_credentials
+          sleep 5
+        done
+      "
+    secrets:
+      - app_credentials
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+    networks:
+      - smoke-network
+
+secrets:
+  app_credentials:
+    driver: swarm-external-secrets:latest
+    labels:
+      swarm-external-secrets.sources: >-
+        [
+          {"path":"database/mysql","field":"password","key":"MYSQL_PASSWORD"},
+          {"path":"database/postgres","field":"password","key":"POSTGRES_PASSWORD"},
+          {"path":"database/redis","field":"password","key":"REDIS_PASSWORD"}
+        ]
+
+networks:
+  smoke-network:
+    driver: overlay

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -185,6 +185,45 @@ verify_secret() {
     die "Secret '${secret_name}' did not match expected value within ${timeout}s."
 }
 
+verify_secret_contains() {
+    local stack_name="$1"
+    local service_suffix="$2"
+    local secret_name="$3"
+    local expected_substring="$4"
+    local timeout="${5:-60}"
+
+    info "Verifying secret '${secret_name}' contains '${expected_substring}'..."
+
+    local elapsed=0
+    while [ "${elapsed}" -lt "${timeout}" ]; do
+        local task_id
+        task_id=$(docker service ps "${stack_name}_${service_suffix}" \
+            --filter "desired-state=running" \
+            --format '{{.ID}}' 2>/dev/null | head -1)
+
+        if [ -n "${task_id}" ]; then
+            local container_id
+            container_id=$(docker inspect "${task_id}" \
+                --format '{{.Status.ContainerStatus.ContainerID}}' 2>/dev/null || true)
+
+            if [ -n "${container_id}" ]; then
+                local actual
+                actual=$(docker exec "${container_id}" \
+                    cat "/run/secrets/${secret_name}" 2>/dev/null || true)
+
+                if echo "${actual}" | grep -Fq "${expected_substring}"; then
+                    success "Secret '${secret_name}' contains expected value '${expected_substring}'."
+                    return 0
+                fi
+            fi
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+
+    die "Secret '${secret_name}' did not contain '${expected_substring}' within ${timeout}s."
+}
+
 # Get the currently running container ID for a swarm service
 get_running_container_id() {
     local stack_name="$1"

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -9,6 +9,8 @@ DEF='\033[0m'
 
 PLUGIN_NAME="swarm-external-secrets:latest"
 
+DESIRED_STATE="desired-state=running"
+
 # Logging
 info()    { echo -e "${BLU}[INFO]${DEF} $*"; }
 success() { echo -e "${GRN}[PASS]${DEF} $*"; }
@@ -117,13 +119,13 @@ deploy_stack() {
 
     info "Waiting for stack '${stack_name}' to be ready (timeout: ${timeout}s)..."
     local elapsed=0
-    while [ "${elapsed}" -lt "${timeout}" ]; do
+    while [[ "${elapsed}" -lt "${timeout}" ]]; do
         local running
         running=$(docker stack ps "${stack_name}" \
-            --filter "desired-state=running" \
+            --filter "${DESIRED_STATE}" \
             --format '{{.CurrentState}}' 2>/dev/null \
             | grep -c "Running" || true)
-        if [ "${running}" -gt 0 ]; then
+        if [[ "${running}" -gt 0 ]]; then
             success "Stack '${stack_name}' is running."
             return 0
         fi
@@ -152,18 +154,18 @@ verify_secret() {
     info "Verifying secret '${secret_name}' matches expected value..."
 
     local elapsed=0
-    while [ "${elapsed}" -lt "${timeout}" ]; do
+    while [[ "${elapsed}" -lt "${timeout}" ]]; do
         local task_id
         task_id=$(docker service ps "${stack_name}_${service_suffix}" \
-            --filter "desired-state=running" \
+            --filter "${DESIRED_STATE}" \
             --format '{{.ID}}' 2>/dev/null | head -1)
 
-        if [ -n "${task_id}" ]; then
+        if [[ -n "${task_id}" ]]; then
             local container_id
             container_id=$(docker inspect "${task_id}" \
                 --format '{{.Status.ContainerStatus.ContainerID}}' 2>/dev/null || true)
 
-            if [ -n "${container_id}" ]; then
+            if [[ -n "${container_id}" ]]; then
                 local actual
                 actual=$(docker exec "${container_id}" \
                     cat "/run/secrets/${secret_name}" 2>/dev/null | tr -d '[:space:]' || true)
@@ -172,7 +174,7 @@ verify_secret() {
 
                 info "Expected: '${expected_trimmed}' | Got: '${actual}'"
 
-                if [ "${actual}" = "${expected_trimmed}" ]; then
+                if [[ "${actual}" == "${expected_trimmed}" ]]; then
                     success "Secret '${secret_name}' verified: value matches expected."
                     return 0
                 fi
@@ -195,18 +197,18 @@ verify_secret_contains() {
     info "Verifying secret '${secret_name}' contains '${expected_substring}'..."
 
     local elapsed=0
-    while [ "${elapsed}" -lt "${timeout}" ]; do
+    while [[ "${elapsed}" -lt "${timeout}" ]]; do
         local task_id
         task_id=$(docker service ps "${stack_name}_${service_suffix}" \
-            --filter "desired-state=running" \
+            --filter "${DESIRED_STATE}" \
             --format '{{.ID}}' 2>/dev/null | head -1)
 
-        if [ -n "${task_id}" ]; then
+        if [[ -n "${task_id}" ]]; then
             local container_id
             container_id=$(docker inspect "${task_id}" \
                 --format '{{.Status.ContainerStatus.ContainerID}}' 2>/dev/null || true)
 
-            if [ -n "${container_id}" ]; then
+            if [[ -n "${container_id}" ]]; then
                 local actual
                 actual=$(docker exec "${container_id}" \
                     cat "/run/secrets/${secret_name}" 2>/dev/null || true)
@@ -230,9 +232,9 @@ get_running_container_id() {
     local service_suffix="$2"
     local task_id
     task_id=$(docker service ps "${stack_name}_${service_suffix}" \
-        --filter "desired-state=running" \
+        --filter "${DESIRED_STATE}" \
         --format '{{.ID}}' 2>/dev/null | head -1)
-    if [ -n "${task_id}" ]; then
+    if [[ -n "${task_id}" ]]; then
         docker inspect "${task_id}" \
             --format '{{.Status.ContainerStatus.ContainerID}}' 2>/dev/null || true
     fi
@@ -244,7 +246,7 @@ remove_stack() {
     info "Removing stack '${stack_name}'..."
     docker stack rm "${stack_name}" 2>/dev/null || true
     local elapsed=0
-    while docker stack ps "${stack_name}" &>/dev/null && [ "${elapsed}" -lt 30 ]; do
+    while docker stack ps "${stack_name}" &>/dev/null && [[ "${elapsed}" -lt 30 ]]; do
         sleep 3
         elapsed=$((elapsed + 3))
     done

--- a/scripts/tests/smoke-test-vault.sh
+++ b/scripts/tests/smoke-test-vault.sh
@@ -26,6 +26,11 @@ MULTI_SOURCE_REDIS="redis-pass-v1"
 MULTI_SOURCE_MYSQL_ROOT_ROTATED="mysql-root-pass-v2"
 MULTI_SOURCE_MYSQL_USER_ROTATED="mysql-user-pass-v2"
 MULTI_SOURCE_REDIS_ROTATED="redis-pass-v2"
+
+# Secret names
+SECRET_APP_CREDENTIALS="app_credentials"
+SECRET_APP_CREDENTIALS_ENV="app_credentials_env"
+
 POLICY_FILE="${REPO_ROOT}/vault_conf/admin.hcl"
 EXIT_CODE=0
 # Cleanup trap
@@ -137,14 +142,14 @@ verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE}" 60
 
 # Verify multi-source JSON secret
 info "Verifying multi-source JSON secret (app_credentials)..."
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "MYSQL_ROOT_PASSWORD" 60
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "MYSQL_USER_PASSWORD" 60
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "REDIS_PASSWORD" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS}" "MYSQL_ROOT_PASSWORD" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS}" "MYSQL_USER_PASSWORD" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS}" "REDIS_PASSWORD" 60
 
 # Verify multi-source ENV secret
 info "Verifying multi-source ENV secret (app_credentials_env)..."
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials_env" "MYSQL_ROOT_PASSWORD" 60
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials_env" "REDIS_PASSWORD" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS_ENV}" "MYSQL_ROOT_PASSWORD" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS_ENV}" "REDIS_PASSWORD" 60
 
 # Capture container ID now, before rotation, to verify in-place update
 info "Capturing running container ID before rotation..."
@@ -193,12 +198,12 @@ info "Waiting for multi-source rotation to propagate (20s)..."
 sleep 20
 
 info "Verifying rotated multi-source JSON secret..."
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "${MULTI_SOURCE_MYSQL_ROOT_ROTATED}" 60
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "${MULTI_SOURCE_MYSQL_USER_ROTATED}" 60
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "${MULTI_SOURCE_REDIS_ROTATED}" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS}" "${MULTI_SOURCE_MYSQL_ROOT_ROTATED}" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS}" "${MULTI_SOURCE_MYSQL_USER_ROTATED}" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS}" "${MULTI_SOURCE_REDIS_ROTATED}" 60
 
 info "Verifying rotated multi-source ENV secret..."
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials_env" "${MULTI_SOURCE_MYSQL_ROOT_ROTATED}" 60
-verify_secret_contains "${STACK_NAME}" "app" "app_credentials_env" "${MULTI_SOURCE_REDIS_ROTATED}" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS_ENV}" "${MULTI_SOURCE_MYSQL_ROOT_ROTATED}" 60
+verify_secret_contains "${STACK_NAME}" "app" "${SECRET_APP_CREDENTIALS_ENV}" "${MULTI_SOURCE_REDIS_ROTATED}" 60
 
 success "Vault smoke test PASSED (incl. multi-source)"

--- a/scripts/tests/smoke-test-vault.sh
+++ b/scripts/tests/smoke-test-vault.sh
@@ -18,6 +18,14 @@ SECRET_FIELD="password"
 SECRET_VALUE="vault-smoke-pass-v1"
 SECRET_VALUE_ROTATED="vault-smoke-pass-v2"
 COMPOSE_FILE="${SCRIPT_DIR}/smoke-vault-compose.yml"
+
+# Multi-source test values
+MULTI_SOURCE_MYSQL_ROOT="mysql-root-pass-v1"
+MULTI_SOURCE_MYSQL_USER="mysql-user-pass-v1"
+MULTI_SOURCE_REDIS="redis-pass-v1"
+MULTI_SOURCE_MYSQL_ROOT_ROTATED="mysql-root-pass-v2"
+MULTI_SOURCE_MYSQL_USER_ROTATED="mysql-user-pass-v2"
+MULTI_SOURCE_REDIS_ROTATED="redis-pass-v2"
 POLICY_FILE="${REPO_ROOT}/vault_conf/admin.hcl"
 EXIT_CODE=0
 # Cleanup trap
@@ -68,6 +76,22 @@ docker exec "${VAULT_CONTAINER}" \
     "${SECRET_FIELD}=${SECRET_VALUE}"
 success "Secret written: secret/${SECRET_PATH} ${SECRET_FIELD}=${SECRET_VALUE}"
 
+# Write multi-source secrets to Vault
+info "Writing multi-source secrets to Vault..."
+docker exec "${VAULT_CONTAINER}" \
+    env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
+    vault kv put \
+    "secret/database/mysql" \
+    "password=${SECRET_VALUE}" \
+    "root_password=${MULTI_SOURCE_MYSQL_ROOT}" \
+    "user_password=${MULTI_SOURCE_MYSQL_USER}"
+docker exec "${VAULT_CONTAINER}" \
+    env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
+    vault kv put \
+    "secret/database/redis" \
+    "password=${MULTI_SOURCE_REDIS}"
+success "Multi-source secrets written."
+
 # Get the tmp auth token from vault
 info "Getting auth token from Vault..."
 VAULT_TOKEN=$(docker exec "${VAULT_CONTAINER}" \
@@ -111,12 +135,23 @@ assert_no_sensitive_rotation_metadata_logs
 info "Verifying secret value matches expected password..."
 verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE}" 60
 
+# Verify multi-source JSON secret
+info "Verifying multi-source JSON secret (app_credentials)..."
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "MYSQL_ROOT_PASSWORD" 60
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "MYSQL_USER_PASSWORD" 60
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "REDIS_PASSWORD" 60
+
+# Verify multi-source ENV secret
+info "Verifying multi-source ENV secret (app_credentials_env)..."
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials_env" "MYSQL_ROOT_PASSWORD" 60
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials_env" "REDIS_PASSWORD" 60
+
 # Capture container ID now, before rotation, to verify in-place update
 info "Capturing running container ID before rotation..."
 APP_CONTAINER_ID=$(get_running_container_id "${STACK_NAME}" "app")
 success "Container to watch: ${APP_CONTAINER_ID:0:12}"
 
-# Rotate the password and verify
+# Rotate single secret and verify
 info "Rotating secret in Vault..."
 docker exec "${VAULT_CONTAINER}" \
     env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
@@ -138,5 +173,32 @@ log_stack "${STACK_NAME}" "app"
 info "Verifying rotated secret value (waiting for in-place update, up to 180s)..."
 verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE_ROTATED}" 180
 
+# Rotate multi-source secrets and verify
+info "Rotating multi-source secrets in Vault..."
+docker exec "${VAULT_CONTAINER}" \
+    env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
+    vault kv put \
+    "secret/database/mysql" \
+    "password=${SECRET_VALUE_ROTATED}" \
+    "root_password=${MULTI_SOURCE_MYSQL_ROOT_ROTATED}" \
+    "user_password=${MULTI_SOURCE_MYSQL_USER_ROTATED}"
+docker exec "${VAULT_CONTAINER}" \
+    env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
+    vault kv put \
+    "secret/database/redis" \
+    "password=${MULTI_SOURCE_REDIS_ROTATED}"
+success "Multi-source secrets rotated."
 
-success "Vault smoke test PASSED"
+info "Waiting for multi-source rotation to propagate (20s)..."
+sleep 20
+
+info "Verifying rotated multi-source JSON secret..."
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "${MULTI_SOURCE_MYSQL_ROOT_ROTATED}" 60
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "${MULTI_SOURCE_MYSQL_USER_ROTATED}" 60
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials" "${MULTI_SOURCE_REDIS_ROTATED}" 60
+
+info "Verifying rotated multi-source ENV secret..."
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials_env" "${MULTI_SOURCE_MYSQL_ROOT_ROTATED}" 60
+verify_secret_contains "${STACK_NAME}" "app" "app_credentials_env" "${MULTI_SOURCE_REDIS_ROTATED}" 60
+
+success "Vault smoke test PASSED (incl. multi-source)"

--- a/scripts/tests/smoke-vault-compose.yml
+++ b/scripts/tests/smoke-vault-compose.yml
@@ -6,12 +6,22 @@ services:
     command: >
       sh -c "
         while true; do
-          echo 'Current secret:' && cat /run/secrets/smoke_secret
+          echo '--- Single secret (smoke_secret) ---'
+          cat /run/secrets/smoke_secret
+          echo ''
+          echo '--- Multi-source JSON (app_credentials) ---'
+          cat /run/secrets/app_credentials
+          echo ''
+          echo '--- Multi-source ENV (app_credentials_env) ---'
+          cat /run/secrets/app_credentials_env
+          echo ''
           sleep 5
         done
       "
     secrets:
       - smoke_secret
+      - app_credentials
+      - app_credentials_env
     deploy:
       replicas: 1
       restart_policy:
@@ -25,6 +35,26 @@ secrets:
     labels:
       vault_path: "database/mysql"
       vault_field: "password"
+
+  app_credentials:
+    driver: swarm-external-secrets:latest
+    labels:
+      swarm-external-secrets.sources: >-
+        [
+          {"path":"database/mysql","field":"root_password","key":"MYSQL_ROOT_PASSWORD"},
+          {"path":"database/mysql","field":"user_password","key":"MYSQL_USER_PASSWORD"},
+          {"path":"database/redis","field":"password","key":"REDIS_PASSWORD"}
+        ]
+
+  app_credentials_env:
+    driver: swarm-external-secrets:latest
+    labels:
+      swarm-external-secrets.sources: >-
+        [
+          {"path":"database/mysql","field":"root_password","key":"MYSQL_ROOT_PASSWORD"},
+          {"path":"database/redis","field":"password","key":"REDIS_PASSWORD"}
+        ]
+      swarm-external-secrets.format: "env"
 
 networks:
   smoke-network:


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change 
ex: - [x] Refactor
-->

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation
- [ ] CI

## Mention the secrets provider 

All (Vault, AWS, Azure, GCP, OpenBao)

## Description

Support mapping multiple external secrets into a single Docker secret via a new `swarm-external-secrets.sources` label. This allows aggregating multiple secret paths/ fields into one mounted secret payload.

**Key changes:**
- Added `secretSource` struct and `swarm-external-secrets.sources` label parsing
- Added `getAggregateSecret()` to fetch multiple sources and combine results
- Added `renderAggregrateSecret()` to fetch multiple sources and combine results
- Added `swarm-external-secrets.format` label (`json` | `env`)
- Added `TestGetAggregateSecretJSON` and `TestGetAggregateSecretEnvFormat` unit tests
- Updated `docs/multi-provider.md` with multi-source examples

**Usage:**

```yaml
secrets:
  app_credentials:
    driver: swarm-external-secrets:latest
    labels:
      swarm-external-secrets.sources: >-
        [
          {"path":"database/mysql","field":"password","key":"MYSQL_PASSWORD"},
          {"path":"database/redis","field":"password","key":"REDIS_PASSWORD"}
        ]
      swarm-external-secrets.format: "env"  # optional, defaults to json

# Output (JSON):
# {"MYSQL_PASSWORD":"...","REDIS_PASSWORD":"..."}

# Output (ENV):
# MYSQL_PASSWORD=...
# REDIS_PASSWORD=...
```


## Commands & Configuration to test

```bash
bash scripts/tests/smoke-test-vault.sh
go test -v ./...
```

## Screenshots & Logs

<img width="1496" height="849" alt="Screenshot From 2026-04-27 20-51-08" src="https://github.com/user-attachments/assets/de65c6c0-aa3e-4643-ad2c-5fb72e796bdd" />


## Related Tickets & Documents

- Related Issue #
- Closes #142 


