### PR TITLE
docs: add DeepWiki badge and README footer link.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 ### Swarm External Secrets
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/sugar-org/swarm-external-secrets/badge)](https://scorecard.dev/viewer/?uri=github.com/sugar-org/swarm-external-secrets) ![Discord](https://img.shields.io/discord/1476983394977054740?logo=discord&color=blue) [![Join our Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white)](https://discord.gg/4NYdBu7bZy)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/sugar-org/swarm-external-secrets/badge)](https://scorecard.dev/viewer/?uri=github.com/sugar-org/swarm-external-secrets) ![Discord](https://img.shields.io/discord/1476983394977054740?logo=discord&color=blue) [![Join our Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white)](https://discord.gg/4NYdBu7bZy) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sugar-org/swarm-external-secrets)
 
 ---
 
@@ -168,3 +168,7 @@ docker plugin set swarm-external-secrets:latest \
 ### License
 
 [BSD-3-Clause license](https://github.com/sugar-org/swarm-external-secrets/blob/main/LICENSE)
+
+## Explore the Repository
+
+If you want to explore the repository or read more, check out [Ask DeepWiki](https://deepwiki.com/sugar-org/swarm-external-secrets).


### PR DESCRIPTION
## Type of change

  - [ ] Refactor
  - [ ] New feature
  - [ ] Bug fix
  - [ ] Optimization
  - [x] Documentation
  - [ ] CI

  ## Mention the secrets provider

  N/A

  ## Description

  - Added the Ask DeepWiki badge next to the existing top badges in `readme.md`.
  - Added a new closing section in `readme.md` to guide users to Ask DeepWiki for repository exploration and further reading.

  ## Commands & Configuration to test

  - Verify the README renders correctly on GitHub.
  - Confirm the new DeepWiki badge link opens: `https://deepwiki.com/sugar-org/swarm-external-secrets`.

  ## Screenshots & Logs

<img width="1512" height="949" alt="Screenshot 2026-04-28 at 10 25 24 PM" src="https://github.com/user-attachments/assets/958e42b0-2c26-4000-aad6-21eaa7ff61ad" />


