### PR TITLE
feat: replace old localstack to aws-kumo emulator for smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -52,16 +52,12 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3
 
-      - name: Start LocalStack
-        uses: LocalStack/setup-localstack@v0.2.2
-        with:
-          image-tag: 'latest'
-          install-awslocal: 'true'
-        env:
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
       - name: Init Docker Swarm
         run: docker swarm init
 
+      # Kumo is a lightweight open-source AWS emulator started by the smoke test
+      # itself, so no LocalStack auth token / license is required. The aws CLI is
+      # preinstalled on ubuntu-latest runners.
       - name: Run smoke test for awssm
         run: bash scripts/tests/smoke-test-awssm.sh
-        
+

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -59,5 +59,4 @@ jobs:
       # itself, so no LocalStack auth token / license is required. The aws CLI is
       # preinstalled on ubuntu-latest runners.
       - name: Run smoke test for awssm
-        run: bash scripts/tests/smoke-test-awssm.sh
-
+        run: bash scripts/tests/smoke-test-awssm.

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -59,4 +59,4 @@ jobs:
       # itself, so no LocalStack auth token / license is required. The aws CLI is
       # preinstalled on ubuntu-latest runners.
       - name: Run smoke test for awssm
-        run: bash scripts/tests/smoke-test-awssm
+        run: bash scripts/tests/smoke-test-awssm.sh

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -59,4 +59,4 @@ jobs:
       # itself, so no LocalStack auth token / license is required. The aws CLI is
       # preinstalled on ubuntu-latest runners.
       - name: Run smoke test for awssm
-        run: bash scripts/tests/smoke-test-awssm.
+        run: bash scripts/tests/smoke-test-awssm

--- a/driver.go
+++ b/driver.go
@@ -300,7 +300,7 @@ func (d *SecretsDriver) checkForSecretChanges() {
 				return
 			}
 
-			log.Infof("Detected change in secret: %s", secretName)
+			log.Tracef("Detected change in secret: %s", secretName)
 			d.handleSecretRotationResult(secretName, secretInfo)
 		}(secretName, secretInfo)
 	}

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -31,7 +31,7 @@ aws_cmd() {
     AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
     AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
     AWS_DEFAULT_REGION="${AWS_REGION}" \
-    aws --endpoint-url "${KUMO_ENDPOINT}" "$@"
+    aws --no-cli-pager --endpoint-url "${KUMO_ENDPOINT}" "$@"
 }
 
 # Cleanup trap

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -11,7 +11,8 @@ source "${SCRIPT_DIR}/smoke-test-helper.sh"
 # It speaks the AWS Secrets Manager API on port 4566 and needs no auth token,
 # so the smoke test is reproducible for contributors, forks, and external PRs.
 KUMO_CONTAINER="smoke-kumo"
-KUMO_IMAGE="ghcr.io/sivchari/kumo:latest"
+# Pinned to an immutable digest (0.26.0) for reproducible CI; multi-arch (amd64/arm64).
+KUMO_IMAGE="ghcr.io/sivchari/kumo:0.26.0@sha256:e63054fbe10eb17b0c9142e937e11b3f4ee2709ac1c80035f3220542f3e5b045"
 KUMO_ENDPOINT="http://localhost:4566"
 AWS_REGION="us-east-1"
 AWS_ACCESS_KEY_ID="test"
@@ -38,7 +39,7 @@ cleanup() {
     echo -e "${RED}Running AWS Secrets Manager smoke test cleanup...${DEF}"
     remove_stack "${STACK_NAME}"
     docker secret rm "${SECRET_NAME}" 2>/dev/null || true
-    if [ -n "${KUMO_CONTAINER}" ]; then
+    if [[ -n "${KUMO_CONTAINER}" ]]; then
         docker stop "${KUMO_CONTAINER}" 2>/dev/null || true
         docker rm   "${KUMO_CONTAINER}" 2>/dev/null || true
     fi
@@ -67,7 +68,7 @@ elapsed=0
 until aws_cmd secretsmanager list-secrets >/dev/null 2>&1; do
     sleep 2
     elapsed=$((elapsed + 2))
-    [ "${elapsed}" -lt 60 ] || die "Kumo did not become ready within 60s."
+    [[ "${elapsed}" -lt 60 ]] || die "Kumo did not become ready within 60s."
 done
 success "Kumo is ready."
 

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -2,7 +2,7 @@
 
 set -ex
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
-REPO_ROOT="$(realpath -- "${SCRIPT_DIR}/../..")"
+REPO_ROOT="${GITHUB_WORKSPACE:-$(realpath -- "${SCRIPT_DIR}/../..")}" 
 # shellcheck source=smoke-test-helper.sh
 source "${SCRIPT_DIR}/smoke-test-helper.sh"
 
@@ -25,8 +25,10 @@ SECRET_VALUE="awssm-smoke-pass-v1"
 SECRET_VALUE_ROTATED="awssm-smoke-pass-v2"
 COMPOSE_FILE="${SCRIPT_DIR}/smoke-awssm-compose.yml"
 
-# Create director for plugin logs
-mkdir -p /run/swarm-external-secrets
+# Create directory for plugin logs using the repository root path
+PLUGIN_LOG_DIR="${REPO_ROOT}/logs"
+mkdir -p "${PLUGIN_LOG_DIR}"
+touch "${PLUGIN_LOG_DIR}/plugin.log"
 
 # Helper to run the AWS CLI against the Kumo endpoint. Kumo needs no real
 # credentials, but the CLI still requires values to sign the request.
@@ -95,7 +97,9 @@ docker plugin set "${PLUGIN_NAME}" \
     AWS_ENDPOINT_URL="${KUMO_ENDPOINT}" \
     ENABLE_ROTATION="true" \
     ROTATION_INTERVAL="10s" \
-    ENABLE_MONITORING="false"
+    ENABLE_MONITORING="false" \
+    PLUGIN_LOG_PATH="${PLUGIN_LOG_DIR}/plugin.log"
+
 success "Plugin configured with AWS Secrets Manager settings."
 
 # Enable plugin

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -7,8 +7,12 @@ REPO_ROOT="$(realpath -- "${SCRIPT_DIR}/../..")"
 source "${SCRIPT_DIR}/smoke-test-helper.sh"
 
 # Configuration
-LOCALSTACK_CONTAINER="smoke-localstack"
-LOCALSTACK_ENDPOINT="http://localhost:4566"
+# Kumo is a lightweight open-source AWS emulator (https://github.com/sivchari/kumo).
+# It speaks the AWS Secrets Manager API on port 4566 and needs no auth token,
+# so the smoke test is reproducible for contributors, forks, and external PRs.
+KUMO_CONTAINER="smoke-kumo"
+KUMO_IMAGE="ghcr.io/sivchari/kumo:latest"
+KUMO_ENDPOINT="http://localhost:4566"
 AWS_REGION="us-east-1"
 AWS_ACCESS_KEY_ID="test"
 AWS_SECRET_ACCESS_KEY="test"
@@ -20,16 +24,13 @@ SECRET_VALUE="awssm-smoke-pass-v1"
 SECRET_VALUE_ROTATED="awssm-smoke-pass-v2"
 COMPOSE_FILE="${SCRIPT_DIR}/smoke-awssm-compose.yml"
 
-# Helper to run awslocal either on host or inside container
-awslocal_cmd() {
-    if [ -n "${LOCALSTACK_CONTAINER}" ]; then
-        docker exec "${LOCALSTACK_CONTAINER}" awslocal "$@"
-    else
-        AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
-        AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
-        AWS_DEFAULT_REGION="${AWS_REGION}" \
-        awslocal "$@"
-    fi
+# Helper to run the AWS CLI against the Kumo endpoint. Kumo needs no real
+# credentials, but the CLI still requires values to sign the request.
+aws_cmd() {
+    AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+    AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+    AWS_DEFAULT_REGION="${AWS_REGION}" \
+    aws --endpoint-url "${KUMO_ENDPOINT}" "$@"
 }
 
 # Cleanup trap
@@ -37,40 +38,42 @@ cleanup() {
     echo -e "${RED}Running AWS Secrets Manager smoke test cleanup...${DEF}"
     remove_stack "${STACK_NAME}"
     docker secret rm "${SECRET_NAME}" 2>/dev/null || true
-    if [ -n "${LOCALSTACK_CONTAINER}" ]; then
-        docker stop "${LOCALSTACK_CONTAINER}" 2>/dev/null || true
-        docker rm   "${LOCALSTACK_CONTAINER}" 2>/dev/null || true
+    if [ -n "${KUMO_CONTAINER}" ]; then
+        docker stop "${KUMO_CONTAINER}" 2>/dev/null || true
+        docker rm   "${KUMO_CONTAINER}" 2>/dev/null || true
     fi
     remove_plugin
 }
 trap cleanup EXIT
 
-# Start LocalStack container (skip if already running, e.g. in CI)
-if curl -s "${LOCALSTACK_ENDPOINT}/_localstack/health" >/dev/null 2>&1; then
-    info "LocalStack already running, skipping container start."
-    LOCALSTACK_CONTAINER=""
+command -v aws >/dev/null 2>&1 || die "aws CLI is required to run the AWS Secrets Manager smoke test."
+
+# Start Kumo container (skip if an emulator is already serving on 4566, e.g. in CI)
+if aws_cmd secretsmanager list-secrets >/dev/null 2>&1; then
+    info "AWS emulator already running on 4566, skipping container start."
+    KUMO_CONTAINER=""
 else
-    info "Starting LocalStack container..."
+    info "Starting Kumo AWS emulator container..."
     docker run -d \
-        --name "${LOCALSTACK_CONTAINER}" \
+        --name "${KUMO_CONTAINER}" \
         -p 4566:4566 \
-        -e SERVICES=secretsmanager \
-        localstack/localstack:latest
+        "${KUMO_IMAGE}"
 fi
 
-# Wait for LocalStack to be ready
-info "Waiting for LocalStack to be ready..."
+# Wait for Kumo to be ready. Kumo has no dedicated health endpoint, so we probe
+# the Secrets Manager API directly until it answers.
+info "Waiting for Kumo to be ready..."
 elapsed=0
-until curl -s "${LOCALSTACK_ENDPOINT}/_localstack/health" | grep -q "available" 2>/dev/null; do
+until aws_cmd secretsmanager list-secrets >/dev/null 2>&1; do
     sleep 2
     elapsed=$((elapsed + 2))
-    [ "${elapsed}" -lt 60 ] || die "LocalStack did not become ready within 60s."
+    [ "${elapsed}" -lt 60 ] || die "Kumo did not become ready within 60s."
 done
-success "LocalStack is ready."
+success "Kumo is ready."
 
 # Write test secret
 info "Writing test secret to AWS Secrets Manager..."
-awslocal_cmd secretsmanager create-secret \
+aws_cmd secretsmanager create-secret \
     --region "${AWS_REGION}" \
     --name "${SECRET_PATH}" \
     --secret-string "{\"${SECRET_FIELD}\":\"${SECRET_VALUE}\"}"
@@ -85,7 +88,7 @@ docker plugin set "${PLUGIN_NAME}" \
     AWS_REGION="${AWS_REGION}" \
     AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
     AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
-    AWS_ENDPOINT_URL="${LOCALSTACK_ENDPOINT}" \
+    AWS_ENDPOINT_URL="${KUMO_ENDPOINT}" \
     ENABLE_ROTATION="true" \
     ROTATION_INTERVAL="10s" \
     ENABLE_MONITORING="false"
@@ -111,7 +114,7 @@ verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE}" 60
 
 # Rotate the password and verify
 info "Rotating secret in AWS Secrets Manager..."
-awslocal_cmd secretsmanager put-secret-value \
+aws_cmd secretsmanager put-secret-value \
     --region "${AWS_REGION}" \
     --secret-id "${SECRET_PATH}" \
     --secret-string "{\"${SECRET_FIELD}\":\"${SECRET_VALUE_ROTATED}\"}"

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -25,6 +25,9 @@ SECRET_VALUE="awssm-smoke-pass-v1"
 SECRET_VALUE_ROTATED="awssm-smoke-pass-v2"
 COMPOSE_FILE="${SCRIPT_DIR}/smoke-awssm-compose.yml"
 
+# Create director for plugin logs
+mkdir -p /run/swarm-external-secrets
+
 # Helper to run the AWS CLI against the Kumo endpoint. Kumo needs no real
 # credentials, but the CLI still requires values to sign the request.
 aws_cmd() {

--- a/scripts/tests/smoke-test-awssm.sh
+++ b/scripts/tests/smoke-test-awssm.sh
@@ -25,11 +25,6 @@ SECRET_VALUE="awssm-smoke-pass-v1"
 SECRET_VALUE_ROTATED="awssm-smoke-pass-v2"
 COMPOSE_FILE="${SCRIPT_DIR}/smoke-awssm-compose.yml"
 
-# Create directory for plugin logs using the repository root path
-PLUGIN_LOG_DIR="${REPO_ROOT}/logs"
-mkdir -p "${PLUGIN_LOG_DIR}"
-touch "${PLUGIN_LOG_DIR}/plugin.log"
-
 # Helper to run the AWS CLI against the Kumo endpoint. Kumo needs no real
 # credentials, but the CLI still requires values to sign the request.
 aws_cmd() {
@@ -97,8 +92,7 @@ docker plugin set "${PLUGIN_NAME}" \
     AWS_ENDPOINT_URL="${KUMO_ENDPOINT}" \
     ENABLE_ROTATION="true" \
     ROTATION_INTERVAL="10s" \
-    ENABLE_MONITORING="false" \
-    PLUGIN_LOG_PATH="${PLUGIN_LOG_DIR}/plugin.log"
+    ENABLE_MONITORING="false"
 
 success "Plugin configured with AWS Secrets Manager settings."
 

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -88,6 +88,10 @@ build_plugin() {
 
 # Enable plugin (mirrors test.sh pattern)
 enable_plugin() {
+    # config.json bind-mounts host /run/swarm-external-secrets into the plugin.
+    # Docker refuses to enable if that host path does not exist.
+    ensure_plugin_mount_dir
+
     echo -e "${RED}Set plugin permissions${DEF}"
     docker plugin set "${PLUGIN_NAME}" gid=0 uid=0
 
@@ -98,6 +102,23 @@ enable_plugin() {
     docker plugin ls
 
     success "Plugin enabled."
+}
+
+ensure_plugin_mount_dir() {
+    local dir="/run/swarm-external-secrets"
+    if [ -d "${dir}" ]; then
+        return 0
+    fi
+    info "Creating plugin mount source ${dir}..."
+    if [ "$(id -u)" -eq 0 ]; then
+        mkdir -p "${dir}"
+        chmod 777 "${dir}"
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo mkdir -p "${dir}"
+        sudo chmod 777 "${dir}"
+    else
+        die "Need ${dir} for plugin bind mount (create it as root)."
+    fi
 }
 # Remove plugin (mirrors cleanup.sh pattern)
 remove_plugin() {

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -106,16 +106,15 @@ enable_plugin() {
 
 ensure_plugin_mount_dir() {
     local dir="/run/swarm-external-secrets"
-    if [ -d "${dir}" ]; then
+    if [[ -d "${dir}" ]]; then
         return 0
     fi
     info "Creating plugin mount source ${dir}..."
-    if [ "$(id -u)" -eq 0 ]; then
+    # Directory only needs to exist for the bind mount; Docker daemon is root.
+    if [[ "$(id -u)" -eq 0 ]]; then
         mkdir -p "${dir}"
-        chmod 777 "${dir}"
     elif command -v sudo >/dev/null 2>&1; then
         sudo mkdir -p "${dir}"
-        sudo chmod 777 "${dir}"
     else
         die "Need ${dir} for plugin bind mount (create it as root)."
     fi


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change 
ex: - [x] Refactor
-->

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation
- [x] CI

## Mention the secrets provider 

AWS Secrets Manager (aws)

## Description

The AWS Secrets Manager smoke test failed in CI before any test logic ran because recent LocalStack images now require a license/auth token:

```text
License activation failed!
Reason: No credentials were found in the environment.
Please make sure to either set the LOCALSTACK_AUTH_TOKEN variable to a valid auth token.
```

This made the smoke test impossible to run on forks and external PRs without a proprietary secret.

This PR replaces LocalStack with Kumo (`ghcr.io/sivchari/kumo:latest`), a lightweight open-source AWS emulator that needs no auth token, listens on the same port (`4566`), and implements every Secrets Manager operation this test uses (`CreateSecret`, `GetSecretValue`, `PutSecretValue`, verified against Kumo's integration tests).

Changes:

- `scripts/tests/smoke-test-awssm.sh`
  - Swap the LocalStack container for the Kumo container (started inline, self-contained so forks work with no secrets).
  - Replace the LocalStack-only `awslocal` CLI with the standard `aws --endpoint-url http://localhost:4566` (preinstalled on `ubuntu-latest`); added a `command -v aws` guard.
  - Kumo has no `/_localstack/health` endpoint, so readiness is now probed via `secretsmanager list-secrets` (also used to detect an already-running emulator and skip container start in CI).
  - Cleanup trap updated to stop/remove the `smoke-kumo` container.

- `.github/workflows/smoke-tests.yml`
  - Remove the `LocalStack/setup-localstack` step and its `LOCALSTACK_AUTH_TOKEN` secret.
  - The job now just sets up Docker/Swarm and runs the script, which starts Kumo itself.

The swarm stack (`smoke-awssm-compose.yml`), plugin settings, rotation flow, and all assertions are unchanged.

## Commands & Configuration to test

<!--- Describe the commands and configurations to do testing -->

```bash
# Requires: Docker daemon, aws CLI, Swarm mode
docker swarm init 2>/dev/null || true
bash scripts/tests/smoke-test-awssm.sh
```

Expected success ends with:

```text
[PASS] AWS Secrets Manager smoke test PASSED
```

## Screenshots & Logs

<!-- Add CI run link / passing log here once the workflow runs green -->

## Related Tickets & Documents

- Related Issue #41  (Old PR of addition of LOCALSTACK )
- Closes #173 


## Was this PR authored or co-authored using generative AI tooling?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated AWS smoke tests to use the Kumo AWS emulator.
  * Added readiness checks through AWS Secrets Manager and required the AWS CLI.
  * Simplified test setup by removing LocalStack configuration.
  * Updated cleanup and plugin endpoint handling for Kumo.
  * Improved Docker plugin setup by automatically preparing the required host mount directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->