### PR TITLE
chore: break down vault and openbao into shared vaultcompat backend + JWT auth

### DIFF
--- a/.github/workflows/lefthook.yml
+++ b/.github/workflows/lefthook.yml
@@ -56,5 +56,8 @@ jobs:
             golangci-lint run ./...
           fi
 
+      - name: Run tests with race detector
+        run: go test -race ./...
+
       - name: Check for uncommitted changes
         run: git diff --exit-code

--- a/config.json
+++ b/config.json
@@ -54,6 +54,31 @@
       "settable": ["value"]
     },
     {
+      "name": "VAULT_APPROLE_AUTH_PATH",
+      "description": "Vault AppRole auth mount path",
+      "settable": ["value"]
+    },
+    {
+      "name": "VAULT_JWT_ROLE",
+      "description": "Vault JWT auth role",
+      "settable": ["value"]
+    },
+    {
+      "name": "VAULT_JWT",
+      "description": "Vault JWT auth token",
+      "settable": ["value"]
+    },
+    {
+      "name": "VAULT_JWT_FILE",
+      "description": "Path to a Vault JWT auth token file",
+      "settable": ["value"]
+    },
+    {
+      "name": "VAULT_JWT_AUTH_PATH",
+      "description": "Vault JWT auth mount path",
+      "settable": ["value"]
+    },
+    {
       "name": "VAULT_MOUNT_PATH",
       "description": "Vault mount path",
       "settable": ["value"]
@@ -81,6 +106,31 @@
     {
       "name": "OPENBAO_SECRET_ID",
       "description": "OpenBao AppRole secret ID",
+      "settable": ["value"]
+    },
+    {
+      "name": "OPENBAO_APPROLE_AUTH_PATH",
+      "description": "OpenBao AppRole auth mount path",
+      "settable": ["value"]
+    },
+    {
+      "name": "OPENBAO_JWT_ROLE",
+      "description": "OpenBao JWT auth role",
+      "settable": ["value"]
+    },
+    {
+      "name": "OPENBAO_JWT",
+      "description": "OpenBao JWT auth token",
+      "settable": ["value"]
+    },
+    {
+      "name": "OPENBAO_JWT_FILE",
+      "description": "Path to an OpenBao JWT auth token file",
+      "settable": ["value"]
+    },
+    {
+      "name": "OPENBAO_JWT_AUTH_PATH",
+      "description": "OpenBao JWT auth mount path",
       "settable": ["value"]
     },
     {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,10 +1,23 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
 )
+
+// SecretInfo tracks information about secrets being managed.
+type SecretInfo struct {
+	DockerSecretName string
+	SecretPath       string
+	SecretField      string
+	ServiceNames     []string
+	LastHash         string
+	LastUpdated      time.Time
+	Provider         string
+	Labels           map[string]string
+}
 
 // getEnvOrDefault returns environment variable value or default
 func GetEnvOrDefault(key, defaultValue string) string {
@@ -46,4 +59,59 @@ func ParseIntOrDefault(intStr string) int {
 		}
 	}
 	return 8080 // Default port
+}
+
+func ExtractSecretValueFromMap(data map[string]interface{}, field string) ([]byte, error) {
+	if field != "" {
+		if value, ok := data[field]; ok {
+			return []byte(fmt.Sprintf("%v", value)), nil
+		}
+
+		keys := make([]string, 0, len(data))
+		for k := range data {
+			keys = append(keys, k)
+		}
+
+		return nil, fmt.Errorf("field %s not found in secret; available fields: %v", field, keys)
+	}
+
+	defaultFields := []string{"value", "password", "secret", "data"}
+	for _, f := range defaultFields {
+		if value, ok := data[f]; ok {
+			return []byte(fmt.Sprintf("%v", value)), nil
+		}
+	}
+
+	for _, value := range data {
+		if strValue, ok := value.(string); ok {
+			return []byte(strValue), nil
+		}
+	}
+
+	return nil, fmt.Errorf("no suitable secret value found")
+}
+
+// ExtractSecretValueFromKV unwraps a KV v2 nested "data" key (if present)
+// and then extracts the field value from the resulting map.
+func ExtractSecretValueFromKV(data map[string]interface{}, field string) ([]byte, error) {
+	if nested, ok := data["data"]; ok {
+		if m, ok := nested.(map[string]interface{}); ok {
+			data = m
+		}
+	}
+	return ExtractSecretValueFromMap(data, field)
+}
+
+func ExtractSecretValue(secretString, field string) ([]byte, error) {
+	var data map[string]interface{}
+
+	if err := json.Unmarshal([]byte(secretString), &data); err == nil {
+		return ExtractSecretValueFromMap(data, field)
+	}
+
+	if field != "" && field != "value" {
+		return nil, fmt.Errorf("field %s not found in non-json secret", field)
+	}
+
+	return []byte(secretString), nil
 }

--- a/internal/vaultcompat/backend.go
+++ b/internal/vaultcompat/backend.go
@@ -1,0 +1,411 @@
+package vaultcompat
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	openbaoapi "github.com/openbao/openbao/api/v2"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/sugar-org/swarm-external-secrets/internal/utils"
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat/login"
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat/vclient"
+)
+
+const (
+	minRenewalDelay     = time.Second
+	renewalRetryWait    = 5 * time.Second
+	renewalRetryMaxWait = time.Minute
+)
+
+type Backend struct {
+	client      vclient.Client
+	config      Config
+	loginMethod login.Method
+
+	authMu sync.Mutex
+	auth   *vclient.Auth
+
+	renewCtx    context.Context
+	renewCancel context.CancelFunc
+	renewWG     sync.WaitGroup
+	newTimer    func() renewalTimer
+}
+
+type renewalTimer interface {
+	C() <-chan time.Time
+	Reset(time.Duration) bool
+	Stop() bool
+}
+
+type timeRenewalTimer struct {
+	timer *time.Timer
+}
+
+func newStoppedRenewalTimer() renewalTimer {
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	return &timeRenewalTimer{timer: timer}
+}
+
+func (t *timeRenewalTimer) C() <-chan time.Time {
+	return t.timer.C
+}
+
+func (t *timeRenewalTimer) Reset(delay time.Duration) bool {
+	return t.timer.Reset(delay)
+}
+
+func (t *timeRenewalTimer) Stop() bool {
+	return t.timer.Stop()
+}
+
+func New(cfg Config) (*Backend, error) {
+	client, err := newClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	loginMethod, err := newLoginMethod(cfg)
+	if err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+
+	auth, err := authenticate(context.Background(), client, loginMethod, cfg)
+	if err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+
+	renewCtx, renewCancel := context.WithCancel(context.Background())
+	backend := &Backend{
+		client:      client,
+		config:      cfg,
+		loginMethod: loginMethod,
+		auth:        auth,
+		renewCtx:    renewCtx,
+		renewCancel: renewCancel,
+		newTimer:    newStoppedRenewalTimer,
+	}
+	backend.startTokenRenewal()
+	log.Printf("Successfully initialized %s provider using %s method", cfg.ProviderName, cfg.AuthMethod)
+	return backend, nil
+}
+
+func (b *Backend) GetSecret(ctx context.Context, secretInfo *utils.SecretInfo) ([]byte, error) {
+	log.Debugf("Reading secret from %s path: %s", b.config.ProviderName, secretInfo.SecretPath)
+
+	secret, err := b.client.Read(ctx, secretInfo.SecretPath)
+	if err != nil && b.canReauthenticate() && vclient.IsAuthError(err) {
+		log.Warnf("Read from %s failed with auth error, re-authenticating", b.config.ProviderName)
+		if authErr := b.reauthenticate(ctx); authErr != nil {
+			return nil, fmt.Errorf("failed to re-authenticate with %s: %w", b.config.ProviderName, authErr)
+		}
+		secret, err = b.client.Read(ctx, secretInfo.SecretPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read secret from %s: %w", b.config.ProviderName, err)
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("secret not found at path: %s", secretInfo.SecretPath)
+	}
+
+	value, err := utils.ExtractSecretValueFromKV(secret.Data, secretInfo.SecretField)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract secret value: %w", err)
+	}
+
+	log.Debugf("Successfully retrieved secret from %s", b.config.ProviderName)
+	return value, nil
+}
+
+func (b *Backend) Close() error {
+	if b.renewCancel != nil {
+		b.renewCancel()
+	}
+	b.renewWG.Wait()
+
+	if b.client == nil {
+		return nil
+	}
+	return b.client.Close()
+}
+
+func newClient(cfg Config) (vclient.Client, error) {
+	tlsCfg := vclient.TLSConfig{
+		CACert:     cfg.CACert,
+		ClientCert: cfg.ClientCert,
+		ClientKey:  cfg.ClientKey,
+		SkipVerify: cfg.SkipVerify,
+	}
+
+	switch cfg.ProviderName {
+	case "openbao":
+		apiConfig := openbaoapi.DefaultConfig()
+		apiConfig.Address = cfg.Address
+		if err := vclient.ConfigureOpenBaoTLS(apiConfig, tlsCfg); err != nil {
+			return nil, fmt.Errorf("failed to configure TLS: %w", err)
+		}
+
+		client, err := openbaoapi.NewClient(apiConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create openbao client: %w", err)
+		}
+
+		return vclient.NewOpenBao(client), nil
+	default:
+		apiConfig := vaultapi.DefaultConfig()
+		apiConfig.Address = cfg.Address
+		if err := vclient.ConfigureHashiVaultTLS(apiConfig, tlsCfg); err != nil {
+			return nil, fmt.Errorf("failed to configure TLS: %w", err)
+		}
+
+		client, err := vaultapi.NewClient(apiConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create vault client: %w", err)
+		}
+
+		return vclient.NewHashiVault(client), nil
+	}
+}
+
+func newLoginMethod(cfg Config) (login.Method, error) {
+	loginCfg, err := cfg.loginConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return login.New(login.Config{
+		Method:          loginCfg.Method,
+		Token:           loginCfg.Token,
+		RoleID:          loginCfg.RoleID,
+		SecretID:        loginCfg.SecretID,
+		AppRoleAuthPath: loginCfg.AppRoleAuthPath,
+		JWTRole:         loginCfg.JWTRole,
+		JWTAuthPath:     loginCfg.JWTAuthPath,
+		JWTSource:       loginCfg.JWTSource,
+	})
+}
+
+func authenticate(
+	ctx context.Context,
+	client vclient.Client,
+	method login.Method,
+	cfg Config,
+) (*vclient.Auth, error) {
+	result, err := method.Login(ctx, client)
+	if err != nil {
+		switch cfg.AuthMethod {
+		case "approle":
+			return nil, fmt.Errorf("approle authentication failed: %w", err)
+		case "jwt":
+			return nil, fmt.Errorf("jwt authentication failed: %w", err)
+		default:
+			return nil, err
+		}
+	}
+
+	if result == nil || result.ClientToken == "" {
+		switch cfg.AuthMethod {
+		case "approle":
+			return nil, fmt.Errorf("no auth info returned from approle login")
+		case "jwt":
+			return nil, fmt.Errorf("no auth info returned from jwt login")
+		default:
+			return nil, fmt.Errorf("authentication returned no client token")
+		}
+	}
+
+	client.SetToken(result.ClientToken)
+	return cloneAuth(result), nil
+}
+
+func (b *Backend) startTokenRenewal() {
+	if !b.canRenewAuth() {
+		return
+	}
+	if b.renewCtx == nil || b.renewCancel == nil {
+		b.renewCtx, b.renewCancel = context.WithCancel(context.Background())
+	}
+	if b.newTimer == nil {
+		b.newTimer = newStoppedRenewalTimer
+	}
+
+	b.renewWG.Add(1)
+	go b.renewLoop()
+}
+
+func (b *Backend) renewLoop() {
+	defer b.renewWG.Done()
+
+	timer := b.newTimer()
+	defer timer.Stop()
+
+	for {
+		delay, ok := b.nextRenewDelay()
+		if !ok {
+			return
+		}
+		if !b.waitForRenewal(timer, delay) {
+			return
+		}
+
+		retryWait := renewalRetryWait
+		for {
+			if err := b.renewOrReauthenticate(b.renewCtx); err != nil {
+				log.Warnf("Failed to renew %s token: %v", b.config.ProviderName, err)
+				if !b.waitForRenewal(timer, retryDelayWithJitter(retryWait)) {
+					return
+				}
+				retryWait = nextRetryWait(retryWait)
+				continue
+			}
+			break
+		}
+	}
+}
+
+func nextRetryWait(current time.Duration) time.Duration {
+	next := current * 2
+	if next > renewalRetryMaxWait {
+		return renewalRetryMaxWait
+	}
+	return next
+}
+
+func retryDelayWithJitter(base time.Duration) time.Duration {
+	jitterLimit := base / 2
+	if jitterLimit <= 0 {
+		return base
+	}
+
+	jitter, err := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(jitterLimit)))
+	if err != nil {
+		return base
+	}
+
+	return base + time.Duration(jitter.Int64())
+}
+
+func (b *Backend) waitForRenewal(timer renewalTimer, delay time.Duration) bool {
+	timer.Reset(delay)
+
+	select {
+	case <-b.renewCtx.Done():
+		timer.Stop()
+		return false
+	case <-timer.C():
+		return true
+	}
+}
+
+func (b *Backend) renewOrReauthenticate(ctx context.Context) error {
+	b.authMu.Lock()
+	defer b.authMu.Unlock()
+
+	renewed, err := b.client.RenewSelf(ctx, 0)
+	if err == nil && renewed != nil {
+		b.updateRenewedAuthLocked(renewed)
+		log.Debugf("Successfully renewed %s token", b.config.ProviderName)
+		return nil
+	}
+
+	if err == nil {
+		err = fmt.Errorf("renew response did not include auth info")
+	}
+	log.Warnf("Renewing %s token failed, attempting re-authentication: %v", b.config.ProviderName, err)
+	if authErr := b.reauthenticateLocked(ctx); authErr != nil {
+		return fmt.Errorf("renew self failed: %v; re-authentication failed: %w", err, authErr)
+	}
+
+	return nil
+}
+
+func (b *Backend) reauthenticate(ctx context.Context) error {
+	b.authMu.Lock()
+	defer b.authMu.Unlock()
+
+	return b.reauthenticateLocked(ctx)
+}
+
+func (b *Backend) reauthenticateLocked(ctx context.Context) error {
+	auth, err := authenticate(ctx, b.client, b.loginMethod, b.config)
+	if err != nil {
+		return err
+	}
+
+	b.auth = auth
+	log.Debugf("Successfully re-authenticated with %s", b.config.ProviderName)
+	return nil
+}
+
+func (b *Backend) updateRenewedAuthLocked(renewed *vclient.Auth) {
+	next := cloneAuth(b.auth)
+	if next == nil {
+		next = &vclient.Auth{}
+	}
+
+	if renewed.ClientToken != "" {
+		b.client.SetToken(renewed.ClientToken)
+		next.ClientToken = renewed.ClientToken
+	}
+	next.Renewable = renewed.Renewable
+	next.LeaseTTL = renewed.LeaseTTL
+	b.auth = next
+}
+
+func (b *Backend) canRenewAuth() bool {
+	if !b.canReauthenticate() {
+		return false
+	}
+
+	b.authMu.Lock()
+	defer b.authMu.Unlock()
+
+	return b.auth != nil && b.auth.Renewable && b.auth.LeaseTTL > 0
+}
+
+func (b *Backend) canReauthenticate() bool {
+	switch b.config.AuthMethod {
+	case "approle", "jwt":
+		return b.loginMethod != nil
+	default:
+		return false
+	}
+}
+
+func (b *Backend) nextRenewDelay() (time.Duration, bool) {
+	b.authMu.Lock()
+	defer b.authMu.Unlock()
+
+	if b.auth == nil || !b.auth.Renewable || b.auth.LeaseTTL <= 0 {
+		return 0, false
+	}
+
+	delay := time.Duration(b.auth.LeaseTTL) * time.Second * 2 / 3
+	if delay < minRenewalDelay {
+		delay = minRenewalDelay
+	}
+
+	return delay, true
+}
+
+func cloneAuth(auth *vclient.Auth) *vclient.Auth {
+	if auth == nil {
+		return nil
+	}
+
+	return &vclient.Auth{
+		ClientToken: auth.ClientToken,
+		Renewable:   auth.Renewable,
+		LeaseTTL:    auth.LeaseTTL,
+	}
+}

--- a/internal/vaultcompat/backend_test.go
+++ b/internal/vaultcompat/backend_test.go
@@ -1,0 +1,379 @@
+package vaultcompat
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sugar-org/swarm-external-secrets/internal/utils"
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat/vclient"
+)
+
+type fakeClientResult struct {
+	secret *vclient.Secret
+	err    error
+}
+
+type fakeAuthResult struct {
+	auth *vclient.Auth
+	err  error
+}
+
+type fakeVaultClient struct {
+	mu sync.Mutex
+
+	readResults  []fakeClientResult
+	writeResults []fakeClientResult
+	renewResults []fakeAuthResult
+
+	readPaths   []string
+	writePaths  []string
+	renewCalls  int
+	setTokens   []string
+	closeCalled bool
+
+	renewCalled chan struct{}
+}
+
+func (f *fakeVaultClient) Read(_ context.Context, path string) (*vclient.Secret, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if len(f.readResults) > 0 {
+		result := f.readResults[0]
+		f.readResults = f.readResults[1:]
+		f.readPaths = append(f.readPaths, path)
+		return result.secret, result.err
+	}
+	f.readPaths = append(f.readPaths, path)
+	return nil, nil
+}
+
+func (f *fakeVaultClient) Write(_ context.Context, path string, _ map[string]any) (*vclient.Secret, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.writePaths = append(f.writePaths, path)
+	if len(f.writeResults) == 0 {
+		return nil, nil
+	}
+
+	result := f.writeResults[0]
+	f.writeResults = f.writeResults[1:]
+	return result.secret, result.err
+}
+
+func (f *fakeVaultClient) RenewSelf(context.Context, int) (*vclient.Auth, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.renewCalls++
+	if f.renewCalled != nil {
+		select {
+		case f.renewCalled <- struct{}{}:
+		default:
+		}
+	}
+	if len(f.renewResults) == 0 {
+		return nil, nil
+	}
+
+	result := f.renewResults[0]
+	f.renewResults = f.renewResults[1:]
+	return result.auth, result.err
+}
+
+func (f *fakeVaultClient) SetToken(token string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.setTokens = append(f.setTokens, token)
+}
+
+func (f *fakeVaultClient) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.closeCalled = true
+	return nil
+}
+
+func (f *fakeVaultClient) tokens() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return slices.Clone(f.setTokens)
+}
+
+func (f *fakeVaultClient) writePathCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.writePaths)
+}
+
+func (f *fakeVaultClient) wasClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.closeCalled
+}
+
+type fakeRenewalTimer struct {
+	ch      chan time.Time
+	delays  chan time.Duration
+	onReset func()
+}
+
+func (f *fakeRenewalTimer) C() <-chan time.Time {
+	return f.ch
+}
+
+func (f *fakeRenewalTimer) Reset(delay time.Duration) bool {
+	if f.delays != nil {
+		f.delays <- delay
+	}
+	if f.onReset != nil {
+		f.onReset()
+	}
+	return true
+}
+
+func (f *fakeRenewalTimer) Stop() bool {
+	return true
+}
+
+func TestBackend_GetSecretReauthenticatesOnAuthError(t *testing.T) {
+	client := &fakeVaultClient{
+		readResults: []fakeClientResult{
+			{err: vclient.ErrAuthFailed},
+			{secret: &vclient.Secret{Data: map[string]any{"data": map[string]any{"password": "rotated"}}}},
+		},
+		writeResults: []fakeClientResult{
+			{secret: &vclient.Secret{Auth: &vclient.Auth{ClientToken: "token-2"}}},
+		},
+	}
+	backend := newTestBackend(t, client, &vclient.Auth{ClientToken: "token-1"})
+	defer func() { _ = backend.Close() }()
+
+	got, err := backend.GetSecret(context.Background(), &utils.SecretInfo{
+		SecretPath:  "secret/data/database",
+		SecretField: "password",
+	})
+	if err != nil {
+		t.Fatalf("GetSecret() error = %v", err)
+	}
+	if string(got) != "rotated" {
+		t.Fatalf("GetSecret() = %q, want rotated", string(got))
+	}
+
+	if client.writePathCount() != 1 {
+		t.Fatalf("write calls = %d, want 1", client.writePathCount())
+	}
+	if !slices.Contains(client.tokens(), "token-2") {
+		t.Fatalf("SetToken calls = %v, want token-2", client.tokens())
+	}
+}
+
+func TestBackend_TokenRenewalUpdatesToken(t *testing.T) {
+	client := &fakeVaultClient{
+		renewCalled: make(chan struct{}, 1),
+		renewResults: []fakeAuthResult{
+			{auth: &vclient.Auth{ClientToken: "token-2", Renewable: true, LeaseTTL: 120}},
+		},
+	}
+	backend := newTestBackend(t, client, &vclient.Auth{
+		ClientToken: "token-1",
+		Renewable:   true,
+		LeaseTTL:    60,
+	})
+	trigger := make(chan time.Time, 1)
+	delays := make(chan time.Duration, 2)
+	backend.newTimer = func() renewalTimer {
+		return &fakeRenewalTimer{
+			ch:     trigger,
+			delays: delays,
+		}
+	}
+	backend.startTokenRenewal()
+	defer func() { _ = backend.Close() }()
+
+	if delay := <-delays; delay != 40*time.Second {
+		t.Fatalf("renew delay = %v, want 40s", delay)
+	}
+	trigger <- time.Now()
+
+	waitFor(t, func() bool {
+		return slices.Contains(client.tokens(), "token-2")
+	})
+}
+
+func TestBackend_TokenRenewalReauthenticatesOnFailure(t *testing.T) {
+	client := &fakeVaultClient{
+		renewCalled: make(chan struct{}, 1),
+		renewResults: []fakeAuthResult{
+			{err: vclient.ErrAuthFailed},
+		},
+		writeResults: []fakeClientResult{
+			{secret: &vclient.Secret{Auth: &vclient.Auth{
+				ClientToken: "token-reauth",
+				Renewable:   true,
+				LeaseTTL:    120,
+			}}},
+		},
+	}
+	backend := newTestBackend(t, client, &vclient.Auth{
+		ClientToken: "token-1",
+		Renewable:   true,
+		LeaseTTL:    60,
+	})
+	trigger := make(chan time.Time, 1)
+	backend.newTimer = func() renewalTimer {
+		return &fakeRenewalTimer{ch: trigger}
+	}
+	backend.startTokenRenewal()
+	defer func() { _ = backend.Close() }()
+
+	trigger <- time.Now()
+
+	waitFor(t, func() bool {
+		return client.writePathCount() == 1 && slices.Contains(client.tokens(), "token-reauth")
+	})
+}
+
+func TestBackend_CloseStopsRenewalWorker(t *testing.T) {
+	client := &fakeVaultClient{}
+	backend := newTestBackend(t, client, &vclient.Auth{
+		ClientToken: "token-1",
+		Renewable:   true,
+		LeaseTTL:    60,
+	})
+	waiting := make(chan struct{}, 1)
+	never := make(chan time.Time)
+	backend.newTimer = func() renewalTimer {
+		return &fakeRenewalTimer{
+			ch: never,
+			onReset: func() {
+				waiting <- struct{}{}
+			},
+		}
+	}
+	backend.startTokenRenewal()
+
+	select {
+	case <-waiting:
+	case <-time.After(time.Second):
+		t.Fatal("renewal worker did not start")
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		if err := backend.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close() did not stop renewal worker")
+	}
+	if !client.wasClosed() {
+		t.Fatal("client was not closed")
+	}
+}
+
+func TestNextRetryWaitCapsAtMax(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{
+			name: "doubles below cap",
+			in:   5 * time.Second,
+			want: 10 * time.Second,
+		},
+		{
+			name: "caps at max",
+			in:   renewalRetryMaxWait,
+			want: renewalRetryMaxWait,
+		},
+		{
+			name: "does not exceed max",
+			in:   45 * time.Second,
+			want: renewalRetryMaxWait,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nextRetryWait(tt.in); got != tt.want {
+				t.Fatalf("nextRetryWait(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryDelayWithJitterStaysWithinExpectedRange(t *testing.T) {
+	base := 10 * time.Second
+
+	for range 100 {
+		got := retryDelayWithJitter(base)
+		if got < base {
+			t.Fatalf("retryDelayWithJitter(%v) = %v, want >= %v", base, got, base)
+		}
+		if got >= base+(base/2) {
+			t.Fatalf("retryDelayWithJitter(%v) = %v, want < %v", base, got, base+(base/2))
+		}
+	}
+}
+
+func newTestBackend(t *testing.T, client vclient.Client, auth *vclient.Auth) *Backend {
+	t.Helper()
+
+	cfg := Config{
+		ProviderName: "vault",
+		AuthMethod:   "jwt",
+		JWTRole:      "swarm-external-secrets",
+		JWT:          "test.jwt.token",
+	}
+	method, err := newLoginMethod(cfg)
+	if err != nil {
+		t.Fatalf("newLoginMethod() error = %v", err)
+	}
+
+	renewCtx, renewCancel := context.WithCancel(context.Background())
+	return &Backend{
+		client:      client,
+		config:      cfg,
+		loginMethod: method,
+		auth:        auth,
+		renewCtx:    renewCtx,
+		renewCancel: renewCancel,
+		newTimer:    newStoppedRenewalTimer,
+	}
+}
+
+func waitFor(t *testing.T, condition func() bool) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if condition() {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatal("condition was not met before timeout")
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/vaultcompat/config.go
+++ b/internal/vaultcompat/config.go
@@ -1,0 +1,188 @@
+package vaultcompat
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sugar-org/swarm-external-secrets/internal/utils"
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat/jwtsource"
+)
+
+type Config struct {
+	ProviderName string
+	EnvPrefix    string
+
+	Address    string
+	MountPath  string
+	AuthMethod string
+
+	Token    string
+	RoleID   string
+	SecretID string
+
+	AppRoleAuthPath string
+
+	JWTRole     string
+	JWT         string
+	JWTFile     string
+	JWTAuthPath string
+
+	CACert     string
+	ClientCert string
+	ClientKey  string
+	SkipVerify bool
+
+	PathLabel  string
+	FieldLabel string
+}
+
+func ParseVaultConfig(config map[string]string) Config {
+	return parseConfig(Config{
+		ProviderName: "vault",
+		EnvPrefix:    "VAULT",
+		PathLabel:    "vault_path",
+		FieldLabel:   "vault_field",
+	}, config, "")
+}
+
+func ParseOpenBaoConfig(config map[string]string) Config {
+	return parseConfig(Config{
+		ProviderName: "openbao",
+		EnvPrefix:    "OPENBAO",
+		PathLabel:    "openbao_path",
+		FieldLabel:   "openbao_field",
+	}, config, "http://localhost:8200")
+}
+
+func parseConfig(base Config, config map[string]string, addressDefault string) Config {
+	prefix := base.EnvPrefix
+
+	base.Address = utils.GetConfigOrDefault(config, prefix+"_ADDR", addressDefault)
+	base.Token = utils.GetConfigOrDefault(config, prefix+"_TOKEN", "")
+	base.MountPath = utils.GetConfigOrDefault(config, prefix+"_MOUNT_PATH", "secret")
+	base.AuthMethod = utils.GetConfigOrDefault(config, prefix+"_AUTH_METHOD", "token")
+	base.RoleID = config[prefix+"_ROLE_ID"]
+	base.SecretID = config[prefix+"_SECRET_ID"]
+	base.AppRoleAuthPath = getConfigOrDefault(config, prefix+"_APPROLE_AUTH_PATH", "approle")
+	base.JWTRole = config[prefix+"_JWT_ROLE"]
+	base.JWT = utils.GetConfigOrDefault(config, prefix+"_JWT", "")
+	base.JWTFile = utils.GetConfigOrDefault(config, prefix+"_JWT_FILE", "")
+	base.JWTAuthPath = utils.GetConfigOrDefault(config, prefix+"_JWT_AUTH_PATH", "jwt")
+	base.CACert = config[prefix+"_CACERT"]
+	base.ClientCert = config[prefix+"_CLIENT_CERT"]
+	base.ClientKey = config[prefix+"_CLIENT_KEY"]
+	base.SkipVerify = utils.GetConfigOrDefault(config, prefix+"_SKIP_VERIFY", "false") == "true"
+
+	return base
+}
+
+func (c Config) validateAuth() error {
+	switch c.AuthMethod {
+	case "token", "":
+		if c.Token == "" {
+			return fmt.Errorf("%s_TOKEN is required for token authentication", c.EnvPrefix)
+		}
+	case "approle":
+		if c.RoleID == "" || c.SecretID == "" {
+			return fmt.Errorf("%s_ROLE_ID and %s_SECRET_ID are required for approle authentication", c.EnvPrefix, c.EnvPrefix)
+		}
+	case "jwt":
+		if c.JWTRole == "" {
+			return fmt.Errorf("%s_JWT_ROLE is required for jwt authentication", c.EnvPrefix)
+		}
+		if _, err := c.buildJWTSource(); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported authentication method: %s", c.AuthMethod)
+	}
+
+	return nil
+}
+
+func (c Config) buildJWTSource() (jwtsource.Source, error) {
+	if c.JWTFile != "" {
+		if err := validateJWTFile(c.JWTFile, c.EnvPrefix+"_JWT_FILE"); err != nil {
+			return nil, err
+		}
+	}
+	if c.JWT == "" && c.JWTFile == "" {
+		return nil, fmt.Errorf("%s_JWT or %s_JWT_FILE is required for jwt authentication", c.EnvPrefix, c.EnvPrefix)
+	}
+
+	var sources []jwtsource.Source
+	if c.JWTFile != "" {
+		sources = append(sources, jwtsource.File{Path: c.JWTFile})
+	} else if c.JWT != "" {
+		sources = append(sources, jwtsource.Static{Value: c.JWT})
+	}
+
+	switch len(sources) {
+	case 0:
+		return nil, fmt.Errorf("%s_JWT or %s_JWT_FILE is required for jwt authentication", c.EnvPrefix, c.EnvPrefix)
+	case 1:
+		return sources[0], nil
+	default:
+		return jwtsource.Chain{Sources: sources}, nil
+	}
+}
+
+func (c Config) loginConfig() (loginCfg loginConfig, err error) {
+	if err := c.validateAuth(); err != nil {
+		return loginCfg, err
+	}
+
+	loginCfg = loginConfig{
+		Method:          c.AuthMethod,
+		Token:           c.Token,
+		RoleID:          c.RoleID,
+		SecretID:        c.SecretID,
+		AppRoleAuthPath: c.AppRoleAuthPath,
+		JWTRole:         c.JWTRole,
+		JWTAuthPath:     c.JWTAuthPath,
+	}
+
+	if c.AuthMethod == "jwt" {
+		loginCfg.JWTSource, err = c.buildJWTSource()
+		if err != nil {
+			return loginCfg, err
+		}
+	}
+
+	return loginCfg, nil
+}
+
+type loginConfig struct {
+	Method          string
+	Token           string
+	RoleID          string
+	SecretID        string
+	AppRoleAuthPath string
+	JWTRole         string
+	JWTAuthPath     string
+	JWTSource       jwtsource.Source
+}
+
+func validateJWTFile(path, envName string) error {
+	data, err := os.ReadFile(path) // #nosec G304 -- file path is explicit plugin configuration.
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %v", envName, err)
+	}
+
+	if strings.TrimSpace(string(data)) == "" {
+		return fmt.Errorf("%s is empty", envName)
+	}
+
+	return nil
+}
+
+func getConfigOrDefault(config map[string]string, key, defaultValue string) string {
+	if value, exists := config[key]; exists && value != "" {
+		return value
+	}
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/internal/vaultcompat/jwtsource/chain.go
+++ b/internal/vaultcompat/jwtsource/chain.go
@@ -1,0 +1,33 @@
+package jwtsource
+
+import (
+	"context"
+	"errors"
+)
+
+type Chain struct {
+	Sources []Source
+}
+
+func (c Chain) Token(ctx context.Context) (string, error) {
+	errs := []error{}
+
+	for _, source := range c.Sources {
+		if source == nil {
+			continue
+		}
+
+		token, err := source.Token(ctx)
+		if err == nil {
+			return token, nil
+		}
+
+		errs = append(errs, err)
+	}
+
+	if len(errs) == 0 {
+		return "", errors.New("no jwt sources configured")
+	}
+
+	return "", errors.Join(errs...)
+}

--- a/internal/vaultcompat/jwtsource/source.go
+++ b/internal/vaultcompat/jwtsource/source.go
@@ -1,0 +1,42 @@
+package jwtsource
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type Source interface {
+	Token(ctx context.Context) (string, error)
+}
+
+type Static struct {
+	Value string
+}
+
+func (s Static) Token(context.Context) (string, error) {
+	token := strings.TrimSpace(s.Value)
+	if token == "" {
+		return "", fmt.Errorf("static jwt is empty")
+	}
+	return token, nil
+}
+
+type File struct {
+	Path string
+}
+
+func (f File) Token(context.Context) (string, error) {
+	data, err := os.ReadFile(f.Path) // #nosec G304 -- path is explicit plugin configuration.
+	if err != nil {
+		return "", fmt.Errorf("read jwt file: %w", err)
+	}
+
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", fmt.Errorf("jwt file is empty")
+	}
+
+	return token, nil
+}

--- a/internal/vaultcompat/login/jwt_test.go
+++ b/internal/vaultcompat/login/jwt_test.go
@@ -1,0 +1,127 @@
+package login
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat/jwtsource"
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat/vclient"
+)
+
+type mockClient struct {
+	write func(ctx context.Context, path string, data map[string]any) (*vclient.Secret, error)
+}
+
+func (m mockClient) Read(context.Context, string) (*vclient.Secret, error) { return nil, nil }
+
+func (m mockClient) Write(ctx context.Context, path string, data map[string]any) (*vclient.Secret, error) {
+	return m.write(ctx, path, data)
+}
+
+func (m mockClient) RenewSelf(context.Context, int) (*vclient.Auth, error) { return nil, nil }
+
+func (m mockClient) SetToken(string) {}
+
+func (m mockClient) Close() error { return nil }
+
+func TestJWT_Login(t *testing.T) {
+	var gotPath string
+	var gotRole string
+	var gotJWT string
+
+	client := mockClient{write: func(_ context.Context, path string, data map[string]any) (*vclient.Secret, error) {
+		gotPath = path
+		gotRole, _ = data["role"].(string)
+		gotJWT, _ = data["jwt"].(string)
+
+		return &vclient.Secret{
+			Auth: &vclient.Auth{ClientToken: "vault-token"},
+		}, nil
+	}}
+
+	method := newJWTMethod(t, "jwt", "swarm-external-secrets", jwtsource.Static{Value: "test.jwt.token"})
+
+	result, err := method.Login(context.Background(), client)
+	if err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+
+	if result.ClientToken != "vault-token" {
+		t.Fatalf("ClientToken = %q, want vault-token", result.ClientToken)
+	}
+	if gotPath != "auth/jwt/login" {
+		t.Fatalf("login path = %q, want auth/jwt/login", gotPath)
+	}
+	if gotRole != "swarm-external-secrets" {
+		t.Fatalf("login role = %q, want swarm-external-secrets", gotRole)
+	}
+	if gotJWT != "test.jwt.token" {
+		t.Fatalf("login jwt = %q, want test.jwt.token", gotJWT)
+	}
+}
+
+func TestJWT_Login_CustomAuthPath(t *testing.T) {
+	var gotPath string
+
+	client := mockClient{write: func(_ context.Context, path string, _ map[string]any) (*vclient.Secret, error) {
+		gotPath = path
+		return &vclient.Secret{Auth: &vclient.Auth{ClientToken: "vault-token"}}, nil
+	}}
+
+	method := newJWTMethod(t, "/oidc/", "swarm-external-secrets", jwtsource.Static{Value: "test.jwt.token"})
+
+	if _, err := method.Login(context.Background(), client); err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+
+	if gotPath != "auth/oidc/login" {
+		t.Fatalf("login path = %q, want auth/oidc/login", gotPath)
+	}
+}
+
+func TestJWT_Login_MissingRole(t *testing.T) {
+	method := newJWTMethod(t, "jwt", "", jwtsource.Static{Value: "token"})
+
+	_, err := method.Login(context.Background(), mockClient{})
+	if err == nil || err.Error() != "jwt role is required" {
+		t.Fatalf("Login() error = %v", err)
+	}
+}
+
+func TestJWT_Login_NoClientToken(t *testing.T) {
+	client := mockClient{write: func(context.Context, string, map[string]any) (*vclient.Secret, error) {
+		return &vclient.Secret{}, nil
+	}}
+
+	method := newJWTMethod(t, "jwt", "swarm-external-secrets", jwtsource.Static{Value: "test.jwt.token"})
+
+	_, err := method.Login(context.Background(), client)
+	if err == nil || err.Error() != "login response did not include a client token" {
+		t.Fatalf("Login() error = %v", err)
+	}
+}
+
+func TestJWT_Login_SourceError(t *testing.T) {
+	method := newJWTMethod(t, "jwt", "swarm-external-secrets", jwtsource.Static{Value: ""})
+
+	_, err := method.Login(context.Background(), mockClient{})
+	if err == nil || err.Error() != "static jwt is empty" {
+		t.Fatalf("Login() error = %v", err)
+	}
+}
+
+func newJWTMethod(t *testing.T, authPath, role string, source jwtsource.Source) Method {
+	t.Helper()
+
+	method, err := New(Config{
+		Method:      "jwt",
+		JWTAuthPath: authPath,
+		JWTRole:     role,
+		JWTSource:   source,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	return method
+}

--- a/internal/vaultcompat/login/login.go
+++ b/internal/vaultcompat/login/login.go
@@ -1,0 +1,123 @@
+package login
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat/jwtsource"
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat/vclient"
+)
+
+type Config struct {
+	Method          string
+	Token           string
+	RoleID          string
+	SecretID        string
+	AppRoleAuthPath string
+	JWTRole         string
+	JWTAuthPath     string
+	JWTSource       jwtsource.Source
+}
+
+type Method interface {
+	Login(ctx context.Context, client vclient.Client) (*vclient.Auth, error)
+}
+
+func New(cfg Config) (Method, error) {
+	switch strings.ToLower(strings.TrimSpace(cfg.Method)) {
+	case "", "token":
+		return tokenLogin{token: cfg.Token}, nil
+	case "approle":
+		return appRoleLogin{
+			roleID:   cfg.RoleID,
+			secretID: cfg.SecretID,
+			authPath: cfg.AppRoleAuthPath,
+		}, nil
+	case "jwt":
+		return jwtLogin{
+			role:     cfg.JWTRole,
+			authPath: cfg.JWTAuthPath,
+			source:   cfg.JWTSource,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported authentication method: %s", cfg.Method)
+	}
+}
+
+type tokenLogin struct {
+	token string
+}
+
+func (t tokenLogin) Login(context.Context, vclient.Client) (*vclient.Auth, error) {
+	if t.token == "" {
+		return nil, fmt.Errorf("token is required")
+	}
+
+	return &vclient.Auth{ClientToken: t.token}, nil
+}
+
+type appRoleLogin struct {
+	roleID   string
+	secretID string
+	authPath string
+}
+
+func (a appRoleLogin) Login(ctx context.Context, client vclient.Client) (*vclient.Auth, error) {
+	secret, err := client.Write(ctx, loginPath(a.authPath), map[string]any{
+		"role_id":   a.roleID,
+		"secret_id": a.secretID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return authFromSecret(secret)
+}
+
+type jwtLogin struct {
+	role     string
+	authPath string
+	source   jwtsource.Source
+}
+
+func (j jwtLogin) Login(ctx context.Context, client vclient.Client) (*vclient.Auth, error) {
+	if j.role == "" {
+		return nil, fmt.Errorf("jwt role is required")
+	}
+	if j.source == nil {
+		return nil, fmt.Errorf("jwt source is required")
+	}
+
+	token, err := j.source.Token(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := client.Write(ctx, loginPath(j.authPath), map[string]any{
+		"role": j.role,
+		"jwt":  token,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return authFromSecret(secret)
+}
+
+func loginPath(authPath string) string {
+	authPath = strings.Trim(authPath, "/")
+	if authPath == "" {
+		authPath = "token"
+	}
+	return path.Join("auth", authPath, "login")
+}
+
+func authFromSecret(secret *vclient.Secret) (*vclient.Auth, error) {
+	if secret == nil || secret.Auth == nil || secret.Auth.ClientToken == "" {
+		return nil, fmt.Errorf("login response did not include a client token")
+	}
+
+	return secret.Auth, nil
+}

--- a/internal/vaultcompat/vclient/client.go
+++ b/internal/vaultcompat/vclient/client.go
@@ -1,0 +1,81 @@
+package vclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	openbaoapi "github.com/openbao/openbao/api/v2"
+)
+
+var ErrAuthFailed = errors.New("vault authentication failed")
+
+type Client interface {
+	Read(ctx context.Context, path string) (*Secret, error)
+	Write(ctx context.Context, path string, data map[string]any) (*Secret, error)
+	RenewSelf(ctx context.Context, increment int) (*Auth, error)
+	SetToken(token string)
+	Close() error
+}
+
+type Secret struct {
+	Data map[string]any
+	Auth *Auth
+}
+
+type Auth struct {
+	ClientToken string
+	Renewable   bool
+	LeaseTTL    int
+}
+
+type TLSConfig struct {
+	CACert     string
+	ClientCert string
+	ClientKey  string
+	SkipVerify bool
+}
+
+func ConfigureHashiVaultTLS(config *vaultapi.Config, tlsCfg TLSConfig) error {
+	return config.ConfigureTLS(&vaultapi.TLSConfig{
+		CACert:     tlsCfg.CACert,
+		ClientCert: tlsCfg.ClientCert,
+		ClientKey:  tlsCfg.ClientKey,
+		Insecure:   tlsCfg.SkipVerify,
+	})
+}
+
+func ConfigureOpenBaoTLS(config *openbaoapi.Config, tlsCfg TLSConfig) error {
+	return config.ConfigureTLS(&openbaoapi.TLSConfig{
+		CACert:     tlsCfg.CACert,
+		ClientCert: tlsCfg.ClientCert,
+		ClientKey:  tlsCfg.ClientKey,
+		Insecure:   tlsCfg.SkipVerify,
+	})
+}
+
+func IsAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrAuthFailed) {
+		return true
+	}
+
+	var vaultErr *vaultapi.ResponseError
+	if errors.As(err, &vaultErr) {
+		return isAuthStatus(vaultErr.StatusCode)
+	}
+
+	var openBaoErr *openbaoapi.ResponseError
+	if errors.As(err, &openBaoErr) {
+		return isAuthStatus(openBaoErr.StatusCode)
+	}
+
+	return false
+}
+
+func isAuthStatus(statusCode int) bool {
+	return statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden
+}

--- a/internal/vaultcompat/vclient/hashi.go
+++ b/internal/vaultcompat/vclient/hashi.go
@@ -1,0 +1,74 @@
+package vclient
+
+import (
+	"context"
+
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+type HashiVault struct {
+	client *vaultapi.Client
+}
+
+func NewHashiVault(client *vaultapi.Client) *HashiVault {
+	return &HashiVault{client: client}
+}
+
+func (h *HashiVault) Read(ctx context.Context, path string) (*Secret, error) {
+	secret, err := h.client.Logical().ReadWithContext(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return fromHashiSecret(secret), nil
+}
+
+func (h *HashiVault) Write(ctx context.Context, path string, data map[string]any) (*Secret, error) {
+	secret, err := h.client.Logical().WriteWithContext(ctx, path, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return fromHashiSecret(secret), nil
+}
+
+func (h *HashiVault) RenewSelf(ctx context.Context, increment int) (*Auth, error) {
+	secret, err := h.client.Auth().Token().RenewSelfWithContext(ctx, increment)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Auth == nil {
+		return nil, nil
+	}
+
+	return &Auth{
+		ClientToken: secret.Auth.ClientToken,
+		Renewable:   secret.Auth.Renewable,
+		LeaseTTL:    secret.Auth.LeaseDuration,
+	}, nil
+}
+
+func (h *HashiVault) SetToken(token string) {
+	h.client.SetToken(token)
+}
+
+func (h *HashiVault) Close() error {
+	return nil
+}
+
+func fromHashiSecret(secret *vaultapi.Secret) *Secret {
+	if secret == nil {
+		return nil
+	}
+
+	out := &Secret{Data: secret.Data}
+	if secret.Auth != nil {
+		out.Auth = &Auth{
+			ClientToken: secret.Auth.ClientToken,
+			Renewable:   secret.Auth.Renewable,
+			LeaseTTL:    secret.Auth.LeaseDuration,
+		}
+	}
+
+	return out
+}

--- a/internal/vaultcompat/vclient/openbao.go
+++ b/internal/vaultcompat/vclient/openbao.go
@@ -1,0 +1,74 @@
+package vclient
+
+import (
+	"context"
+
+	openbaoapi "github.com/openbao/openbao/api/v2"
+)
+
+type OpenBao struct {
+	client *openbaoapi.Client
+}
+
+func NewOpenBao(client *openbaoapi.Client) *OpenBao {
+	return &OpenBao{client: client}
+}
+
+func (o *OpenBao) Read(ctx context.Context, path string) (*Secret, error) {
+	secret, err := o.client.Logical().ReadWithContext(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return fromOpenBaoSecret(secret), nil
+}
+
+func (o *OpenBao) Write(ctx context.Context, path string, data map[string]any) (*Secret, error) {
+	secret, err := o.client.Logical().WriteWithContext(ctx, path, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return fromOpenBaoSecret(secret), nil
+}
+
+func (o *OpenBao) RenewSelf(ctx context.Context, increment int) (*Auth, error) {
+	secret, err := o.client.Auth().Token().RenewSelfWithContext(ctx, increment)
+	if err != nil {
+		return nil, err
+	}
+	if secret == nil || secret.Auth == nil {
+		return nil, nil
+	}
+
+	return &Auth{
+		ClientToken: secret.Auth.ClientToken,
+		Renewable:   secret.Auth.Renewable,
+		LeaseTTL:    secret.Auth.LeaseDuration,
+	}, nil
+}
+
+func (o *OpenBao) SetToken(token string) {
+	o.client.SetToken(token)
+}
+
+func (o *OpenBao) Close() error {
+	return nil
+}
+
+func fromOpenBaoSecret(secret *openbaoapi.Secret) *Secret {
+	if secret == nil {
+		return nil
+	}
+
+	out := &Secret{Data: secret.Data}
+	if secret.Auth != nil {
+		out.Auth = &Auth{
+			ClientToken: secret.Auth.ClientToken,
+			Renewable:   secret.Auth.Renewable,
+			LeaseTTL:    secret.Auth.LeaseDuration,
+		}
+	}
+
+	return out
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,7 +32,7 @@ pre-commit:
 
     gosec:
       glob: "**/*.go"
-      run: gosec ./...
+      run: gosec -exclude=G101,G117 ./...
 
     eof-newline:
       help: Fail when a staged file does not end with a POSIX newline

--- a/providers/common.go
+++ b/providers/common.go
@@ -1,62 +1,17 @@
 package providers
 
-import (
-	"encoding/json"
-	"fmt"
-)
+import "github.com/sugar-org/swarm-external-secrets/internal/utils"
 
 func ExtractSecretValueFromMap(data map[string]interface{}, field string) ([]byte, error) {
-	if field != "" {
-		if value, ok := data[field]; ok {
-			return []byte(fmt.Sprintf("%v", value)), nil
-		}
-
-		keys := make([]string, 0, len(data))
-		for k := range data {
-			keys = append(keys, k)
-		}
-
-		return nil, fmt.Errorf("field %s not found in secret; available fields: %v", field, keys)
-	}
-
-	defaultFields := []string{"value", "password", "secret", "data"}
-
-	for _, f := range defaultFields {
-		if value, ok := data[f]; ok {
-			return []byte(fmt.Sprintf("%v", value)), nil
-		}
-	}
-
-	for _, value := range data {
-		if strValue, ok := value.(string); ok {
-			return []byte(strValue), nil
-		}
-	}
-
-	return nil, fmt.Errorf("no suitable secret value found")
+	return utils.ExtractSecretValueFromMap(data, field)
 }
 
 // ExtractSecretValueFromKV unwraps a KV v2 nested "data" key (if present)
 // and then extracts the field value from the resulting map.
 func ExtractSecretValueFromKV(data map[string]interface{}, field string) ([]byte, error) {
-	if nested, ok := data["data"]; ok {
-		if m, ok := nested.(map[string]interface{}); ok {
-			data = m
-		}
-	}
-	return ExtractSecretValueFromMap(data, field)
+	return utils.ExtractSecretValueFromKV(data, field)
 }
 
 func ExtractSecretValue(secretString, field string) ([]byte, error) {
-	var data map[string]interface{}
-
-	if err := json.Unmarshal([]byte(secretString), &data); err == nil {
-		return ExtractSecretValueFromMap(data, field)
-	}
-
-	if field != "" && field != "value" {
-		return nil, fmt.Errorf("field %s not found in non-json secret", field)
-	}
-
-	return []byte(secretString), nil
+	return utils.ExtractSecretValue(secretString, field)
 }

--- a/providers/factory.go
+++ b/providers/factory.go
@@ -42,8 +42,8 @@ func GetProviderInfo(providerType string) (map[string]string, error) {
 	case "vault", "hashicorp-vault":
 		info["name"] = "HashiCorp Vault"
 		info["description"] = "HashiCorp Vault secrets engine"
-		info["auth_methods"] = "token, approle"
-		info["env_vars"] = "VAULT_ADDR, VAULT_TOKEN, VAULT_MOUNT_PATH, VAULT_AUTH_METHOD, VAULT_ROLE_ID, VAULT_SECRET_ID"
+		info["auth_methods"] = "token, approle, jwt"
+		info["env_vars"] = "VAULT_ADDR, VAULT_TOKEN, VAULT_MOUNT_PATH, VAULT_AUTH_METHOD, VAULT_ROLE_ID, VAULT_SECRET_ID, VAULT_APPROLE_AUTH_PATH, VAULT_JWT_ROLE, VAULT_JWT, VAULT_JWT_FILE, VAULT_JWT_AUTH_PATH"
 
 	case "aws", "aws-secrets-manager":
 		info["name"] = "AWS Secrets Manager"
@@ -66,8 +66,8 @@ func GetProviderInfo(providerType string) (map[string]string, error) {
 	case "openbao":
 		info["name"] = "OpenBao"
 		info["description"] = "OpenBao secrets engine (Vault-compatible)"
-		info["auth_methods"] = "token, approle"
-		info["env_vars"] = "OPENBAO_ADDR, OPENBAO_TOKEN, OPENBAO_MOUNT_PATH, OPENBAO_AUTH_METHOD, OPENBAO_ROLE_ID, OPENBAO_SECRET_ID"
+		info["auth_methods"] = "token, approle, jwt"
+		info["env_vars"] = "OPENBAO_ADDR, OPENBAO_TOKEN, OPENBAO_MOUNT_PATH, OPENBAO_AUTH_METHOD, OPENBAO_ROLE_ID, OPENBAO_SECRET_ID, OPENBAO_APPROLE_AUTH_PATH, OPENBAO_JWT_ROLE, OPENBAO_JWT, OPENBAO_JWT_FILE, OPENBAO_JWT_AUTH_PATH"
 
 	default:
 		return nil, fmt.Errorf("unsupported provider type: %s", providerType)

--- a/providers/interface.go
+++ b/providers/interface.go
@@ -5,20 +5,12 @@ import (
 	"time"
 
 	"github.com/docker/go-plugins-helpers/secrets"
+
+	"github.com/sugar-org/swarm-external-secrets/internal/utils"
 )
 
 // SecretInfo tracks information about secrets being managed
-type SecretInfo struct {
-	DockerSecretName string
-	SecretPath       string
-	SecretField      string
-	SecretLabels     map[string]string
-	ServiceNames     []string
-	LastHash         string // Hash of the secret value for change detection
-	LastUpdated      time.Time
-	Provider         string            // Which provider manages this secret
-	Labels           map[string]string // Original request labels, used to reconstruct requests for rotation
-}
+type SecretInfo = utils.SecretInfo
 
 // SecretsProvider defines the interface that all secret providers must implement
 type SecretsProvider interface {

--- a/providers/openbao.go
+++ b/providers/openbao.go
@@ -6,119 +6,50 @@ import (
 	"path"
 
 	"github.com/docker/go-plugins-helpers/secrets"
-	"github.com/openbao/openbao/api/v2"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/sugar-org/swarm-external-secrets/internal/kvpath"
-	"github.com/sugar-org/swarm-external-secrets/internal/utils"
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat"
 )
 
-// OpenBaoProvider implements the SecretsProvider interface for OpenBao
-// OpenBao is Vault-compatible, so we can reuse most of the Vault logic
+// OpenBaoProvider implements the SecretsProvider interface for OpenBao.
 type OpenBaoProvider struct {
-	client *api.Client
-	config *OpenBaoConfig
+	backend *vaultcompat.Backend
+	config  vaultcompat.Config
 }
 
-// OpenBaoConfig holds the configuration for the OpenBao client
-type OpenBaoConfig struct {
-	Address    string
-	Token      string
-	MountPath  string
-	RoleID     string
-	SecretID   string
-	AuthMethod string
-	CACert     string
-	ClientCert string
-	ClientKey  string // #nosec G117
-	SkipVerify bool
-}
-
-// Initialize sets up the OpenBao provider with the given configuration
+// Initialize sets up the OpenBao provider with the given configuration.
 func (o *OpenBaoProvider) Initialize(config map[string]string) error {
-	o.config = &OpenBaoConfig{
-		Address:    utils.GetConfigOrDefault(config, "OPENBAO_ADDR", "http://localhost:8200"),
-		Token:      config["OPENBAO_TOKEN"],
-		MountPath:  utils.GetConfigOrDefault(config, "OPENBAO_MOUNT_PATH", "secret"),
-		RoleID:     config["OPENBAO_ROLE_ID"],
-		SecretID:   config["OPENBAO_SECRET_ID"],
-		AuthMethod: utils.GetConfigOrDefault(config, "OPENBAO_AUTH_METHOD", "token"),
-		CACert:     config["OPENBAO_CACERT"],
-		ClientCert: config["OPENBAO_CLIENT_CERT"],
-		ClientKey:  config["OPENBAO_CLIENT_KEY"],
-		SkipVerify: utils.GetConfigOrDefault(config, "OPENBAO_SKIP_VERIFY", "false") == "true",
-	}
+	cfg := vaultcompat.ParseOpenBaoConfig(config)
 
-	// Configure OpenBao client (using OpenBao API client since OpenBao is compatible)
-	openBaoConfig := api.DefaultConfig()
-	openBaoConfig.Address = o.config.Address
-
-	// Configure TLS if certificates are provided or verification is skipped
-	if o.config.CACert != "" || o.config.ClientCert != "" || o.config.SkipVerify {
-		tlsConfig := &api.TLSConfig{
-			CACert:     o.config.CACert,
-			ClientCert: o.config.ClientCert,
-			ClientKey:  o.config.ClientKey,
-			Insecure:   o.config.SkipVerify,
-		}
-		if err := openBaoConfig.ConfigureTLS(tlsConfig); err != nil {
-			return fmt.Errorf("failed to configure TLS: %v", err)
-		}
-	}
-
-	client, err := api.NewClient(openBaoConfig)
+	backend, err := vaultcompat.New(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create OpenBao client: %v", err)
-	}
-
-	o.client = client
-
-	// Authenticate with OpenBao
-	if err := o.authenticate(); err != nil {
 		return fmt.Errorf("failed to authenticate with OpenBao: %v", err)
 	}
 
-	log.Infof("Successfully initialized OpenBao provider using %s method", o.config.AuthMethod)
+	o.backend = backend
+	o.config = cfg
 	return nil
 }
 
-// GetSecret retrieves a secret value from OpenBao
+// GetSecret retrieves a secret value from OpenBao.
 func (o *OpenBaoProvider) GetSecret(ctx context.Context, secretInfo *SecretInfo) ([]byte, error) {
-	log.Debugf("Reading secret from OpenBao path: %s", secretInfo.SecretPath)
-
-	// Read secret from OpenBao
-	secret, err := o.client.Logical().ReadWithContext(ctx, secretInfo.SecretPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read secret from OpenBao: %v", err)
-	}
-
-	if secret == nil {
-		return nil, fmt.Errorf("secret not found at path: %s", secretInfo.SecretPath)
-	}
-
-	// Extract the secret value (unwraps KV v2 nested data if present)
-	value, err := ExtractSecretValueFromKV(secret.Data, secretInfo.SecretField)
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract secret value: %v", err)
-	}
-
-	log.Debug("Successfully retrieved secret from OpenBao")
-	return value, nil
+	return o.backend.GetSecret(ctx, secretInfo)
 }
 
-// SupportsRotation indicates that OpenBao supports secret rotation monitoring
+// SupportsRotation indicates that OpenBao supports secret rotation monitoring.
 func (o *OpenBaoProvider) SupportsRotation() bool {
 	return true
 }
 
-// GetSecretFieldLabel returns the label key used by OpenBao for the secret field
+// GetSecretFieldLabel returns the label key used by OpenBao for the secret field.
 func (o *OpenBaoProvider) GetSecretFieldLabel() string {
-	return "openbao_field"
+	return o.config.FieldLabel
 }
 
-// BuildSecretPath constructs the OpenBao secret path based on request labels and service information
+// BuildSecretPath constructs the OpenBao secret path based on request labels and service information.
 func (o *OpenBaoProvider) BuildSecretPath(req secrets.Request) string {
-	if customPath, exists := req.SecretLabels["openbao_path"]; exists && customPath != "" {
+	if customPath, exists := req.SecretLabels[o.config.PathLabel]; exists && customPath != "" {
 		return kvpath.BuildMountedKVv2SecretPath(o.config.MountPath, customPath, "")
 	}
 
@@ -130,49 +61,20 @@ func (o *OpenBaoProvider) BuildSecretPath(req secrets.Request) string {
 	return kvpath.BuildMountedKVv2SecretPath(o.config.MountPath, "", secretName)
 }
 
-// GetProviderName returns the name of this provider
+// GetProviderName returns the name of this provider.
 func (o *OpenBaoProvider) GetProviderName() string {
 	return "openbao"
 }
 
-// Close performs cleanup for the OpenBao provider
+// Close performs cleanup for the OpenBao provider.
 func (o *OpenBaoProvider) Close() error {
-	// OpenBao client doesn't require explicit cleanup
-	return nil
-}
+	if o.backend == nil {
+		return nil
+	}
 
-// authenticate handles various OpenBao authentication methods
-func (o *OpenBaoProvider) authenticate() error {
-	switch o.config.AuthMethod {
-	case "token":
-		if o.config.Token == "" {
-			return fmt.Errorf("OPENBAO_TOKEN is required for token authentication")
-		}
-		o.client.SetToken(o.config.Token)
-
-	case "approle":
-		if o.config.RoleID == "" || o.config.SecretID == "" {
-			return fmt.Errorf("OPENBAO_ROLE_ID and OPENBAO_SECRET_ID are required for approle authentication")
-		}
-
-		data := map[string]interface{}{
-			"role_id":   o.config.RoleID,
-			"secret_id": o.config.SecretID,
-		}
-
-		resp, err := o.client.Logical().Write("auth/approle/login", data)
-		if err != nil {
-			return fmt.Errorf("approle authentication failed: %v", err)
-		}
-
-		if resp.Auth == nil {
-			return fmt.Errorf("no auth info returned from approle login")
-		}
-
-		o.client.SetToken(resp.Auth.ClientToken)
-
-	default:
-		return fmt.Errorf("unsupported authentication method: %s", o.config.AuthMethod)
+	if err := o.backend.Close(); err != nil {
+		log.Printf("Error closing OpenBao provider: %v", err)
+		return err
 	}
 
 	return nil

--- a/providers/vault.go
+++ b/providers/vault.go
@@ -6,118 +6,50 @@ import (
 	"path"
 
 	"github.com/docker/go-plugins-helpers/secrets"
-	"github.com/hashicorp/vault/api"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/sugar-org/swarm-external-secrets/internal/kvpath"
-	"github.com/sugar-org/swarm-external-secrets/internal/utils"
+	"github.com/sugar-org/swarm-external-secrets/internal/vaultcompat"
 )
 
-// VaultProvider implements the SecretsProvider interface for HashiCorp Vault
+// VaultProvider implements the SecretsProvider interface for HashiCorp Vault.
 type VaultProvider struct {
-	client *api.Client
-	config *SecretsConfig
+	backend *vaultcompat.Backend
+	config  vaultcompat.Config
 }
 
-// SecretsConfig holds the configuration for the Vault client
-type SecretsConfig struct {
-	Address    string
-	Token      string
-	MountPath  string
-	RoleID     string
-	SecretID   string
-	AuthMethod string
-	CACert     string
-	ClientCert string
-	ClientKey  string // #nosec G117
-	SkipVerify bool
-}
-
-// Initialize sets up the Vault provider with the given configuration
+// Initialize sets up the Vault provider with the given configuration.
 func (v *VaultProvider) Initialize(config map[string]string) error {
-	v.config = &SecretsConfig{
-		Address:    utils.GetConfigOrDefault(config, "VAULT_ADDR", ""),
-		Token:      utils.GetConfigOrDefault(config, "VAULT_TOKEN", ""),
-		MountPath:  utils.GetConfigOrDefault(config, "VAULT_MOUNT_PATH", "secret"),
-		RoleID:     config["VAULT_ROLE_ID"],
-		SecretID:   config["VAULT_SECRET_ID"],
-		AuthMethod: utils.GetConfigOrDefault(config, "VAULT_AUTH_METHOD", "token"),
-		CACert:     config["VAULT_CACERT"],
-		ClientCert: config["VAULT_CLIENT_CERT"],
-		ClientKey:  config["VAULT_CLIENT_KEY"],
-		SkipVerify: utils.GetConfigOrDefault(config, "VAULT_SKIP_VERIFY", "false") == "true",
-	}
+	cfg := vaultcompat.ParseVaultConfig(config)
 
-	// Configure Vault client
-	SecretsConfig := api.DefaultConfig()
-	SecretsConfig.Address = v.config.Address
-
-	// Configure TLS if certificates are provided or verification is skipped
-	if v.config.CACert != "" || v.config.ClientCert != "" || v.config.SkipVerify {
-		tlsConfig := &api.TLSConfig{
-			CACert:     v.config.CACert,
-			ClientCert: v.config.ClientCert,
-			ClientKey:  v.config.ClientKey,
-			Insecure:   v.config.SkipVerify,
-		}
-		if err := SecretsConfig.ConfigureTLS(tlsConfig); err != nil {
-			return fmt.Errorf("failed to configure TLS: %v", err)
-		}
-	}
-
-	client, err := api.NewClient(SecretsConfig)
+	backend, err := vaultcompat.New(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create vault client: %v", err)
-	}
-
-	v.client = client
-
-	// Authenticate with Vault
-	if err := v.authenticate(); err != nil {
 		return fmt.Errorf("failed to authenticate with vault: %v", err)
 	}
 
-	log.Infof("Successfully initialized Vault provider using %s method", v.config.AuthMethod)
+	v.backend = backend
+	v.config = cfg
 	return nil
 }
 
-// GetSecret retrieves a secret value from Vault
+// GetSecret retrieves a secret value from Vault.
 func (v *VaultProvider) GetSecret(ctx context.Context, secretInfo *SecretInfo) ([]byte, error) {
-	log.Debugf("Reading secret from Vault/OpenBao path: %s", secretInfo.SecretPath)
-
-	// Read secret from Vault
-	secret, err := v.client.Logical().ReadWithContext(ctx, secretInfo.SecretPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read secret from vault: %v", err)
-	}
-
-	if secret == nil {
-		return nil, fmt.Errorf("secret not found at path: %s", secretInfo.SecretPath)
-	}
-
-	// Extract the secret value (unwraps KV v2 nested data if present)
-	value, err := ExtractSecretValueFromKV(secret.Data, secretInfo.SecretField)
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract secret value: %v", err)
-	}
-
-	log.Debug("Successfully retrieved secret from Vault")
-	return value, nil
+	return v.backend.GetSecret(ctx, secretInfo)
 }
 
-// SupportsRotation indicates that Vault supports secret rotation monitoring
+// SupportsRotation indicates that Vault supports secret rotation monitoring.
 func (v *VaultProvider) SupportsRotation() bool {
 	return true
 }
 
-// GetSecretFieldLabel returns the label key used by Vault for the secret field
+// GetSecretFieldLabel returns the label key used by Vault for the secret field.
 func (v *VaultProvider) GetSecretFieldLabel() string {
-	return "vault_field"
+	return v.config.FieldLabel
 }
 
-// BuildSecretPath constructs the Vault secret path based on request labels and service information
+// BuildSecretPath constructs the Vault secret path based on request labels and service information.
 func (v *VaultProvider) BuildSecretPath(req secrets.Request) string {
-	if customPath, exists := req.SecretLabels["vault_path"]; exists && customPath != "" {
+	if customPath, exists := req.SecretLabels[v.config.PathLabel]; exists && customPath != "" {
 		return kvpath.BuildMountedKVv2SecretPath(v.config.MountPath, customPath, "")
 	}
 
@@ -129,49 +61,20 @@ func (v *VaultProvider) BuildSecretPath(req secrets.Request) string {
 	return kvpath.BuildMountedKVv2SecretPath(v.config.MountPath, "", secretName)
 }
 
-// GetProviderName returns the name of this provider
+// GetProviderName returns the name of this provider.
 func (v *VaultProvider) GetProviderName() string {
 	return "vault"
 }
 
-// Close performs cleanup for the Vault provider
+// Close performs cleanup for the Vault provider.
 func (v *VaultProvider) Close() error {
-	// Vault client doesn't require explicit cleanup
-	return nil
-}
+	if v.backend == nil {
+		return nil
+	}
 
-// authenticate handles various Vault authentication methods
-func (v *VaultProvider) authenticate() error {
-	switch v.config.AuthMethod {
-	case "token":
-		if v.config.Token == "" {
-			return fmt.Errorf("VAULT_TOKEN is required for token authentication")
-		}
-		v.client.SetToken(v.config.Token)
-
-	case "approle":
-		if v.config.RoleID == "" || v.config.SecretID == "" {
-			return fmt.Errorf("VAULT_ROLE_ID and VAULT_SECRET_ID are required for approle authentication")
-		}
-
-		data := map[string]interface{}{
-			"role_id":   v.config.RoleID,
-			"secret_id": v.config.SecretID,
-		}
-
-		resp, err := v.client.Logical().Write("auth/approle/login", data)
-		if err != nil {
-			return fmt.Errorf("approle authentication failed: %v", err)
-		}
-
-		if resp.Auth == nil {
-			return fmt.Errorf("no auth info returned from approle login")
-		}
-
-		v.client.SetToken(resp.Auth.ClientToken)
-
-	default:
-		return fmt.Errorf("unsupported authentication method: %s", v.config.AuthMethod)
+	if err := v.backend.Close(); err != nil {
+		log.Printf("Error closing Vault provider: %v", err)
+		return err
 	}
 
 	return nil

--- a/providers/vault_test.go
+++ b/providers/vault_test.go
@@ -1,0 +1,300 @@
+package providers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/docker/go-plugins-helpers/secrets"
+)
+
+func TestVaultProvider_AuthenticateWithJWT(t *testing.T) {
+	var loginRequest struct {
+		Role string `json:"role"`
+		JWT  string `json:"jwt"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/jwt/login":
+			if r.Method != http.MethodPut {
+				t.Fatalf("jwt login method = %s, want PUT", r.Method)
+			}
+
+			if err := json.NewDecoder(r.Body).Decode(&loginRequest); err != nil {
+				t.Fatalf("decode jwt login request: %v", err)
+			}
+
+			_, _ = w.Write([]byte(`{"auth":{"client_token":"vault-client-token"}}`))
+		case "/v1/secret/data/database/mysql":
+			if got := r.Header.Get("X-Vault-Token"); got != "vault-client-token" {
+				t.Fatalf("X-Vault-Token = %q, want vault-client-token", got)
+			}
+
+			_, _ = w.Write([]byte(`{"data":{"data":{"password":"jwt-secret"}}}`))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider := &VaultProvider{}
+	if err := provider.Initialize(map[string]string{
+		"VAULT_ADDR":        server.URL,
+		"VAULT_AUTH_METHOD": "jwt",
+		"VAULT_JWT_ROLE":    "swarm-external-secrets",
+		"VAULT_JWT":         "test.jwt.token",
+		"VAULT_MOUNT_PATH":  "secret",
+	}); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	defer func() { _ = provider.Close() }()
+
+	req := secrets.Request{
+		SecretName: "fallback",
+		SecretLabels: map[string]string{
+			"vault_path":  "database/mysql",
+			"vault_field": "password",
+		},
+	}
+
+	got, err := provider.GetSecret(t.Context(), &SecretInfo{
+		DockerSecretName: req.SecretName,
+		SecretPath:       provider.BuildSecretPath(req),
+		SecretField:      req.SecretLabels[provider.GetSecretFieldLabel()],
+		Provider:         provider.GetProviderName(),
+		Labels:           req.SecretLabels,
+	})
+	if err != nil {
+		t.Fatalf("GetSecret() error = %v", err)
+	}
+
+	if string(got) != "jwt-secret" {
+		t.Fatalf("GetSecret() = %q, want jwt-secret", string(got))
+	}
+
+	if loginRequest.Role != "swarm-external-secrets" {
+		t.Fatalf("login role = %q, want swarm-external-secrets", loginRequest.Role)
+	}
+
+	if loginRequest.JWT != "test.jwt.token" {
+		t.Fatalf("login jwt = %q, want test.jwt.token", loginRequest.JWT)
+	}
+}
+
+func TestVaultProvider_RenewsJWTToken(t *testing.T) {
+	renewCalled := make(chan struct{})
+	var closeRenewCalled sync.Once
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/jwt/login":
+			_, _ = w.Write([]byte(`{"auth":{"client_token":"token-1","renewable":true,"lease_duration":1}}`))
+		case "/v1/auth/token/renew-self":
+			if r.Method != http.MethodPut {
+				t.Fatalf("renew method = %s, want PUT", r.Method)
+			}
+			if got := r.Header.Get("X-Vault-Token"); got != "token-1" {
+				t.Fatalf("renew X-Vault-Token = %q, want token-1", got)
+			}
+
+			closeRenewCalled.Do(func() {
+				close(renewCalled)
+			})
+			_, _ = w.Write([]byte(`{"auth":{"client_token":"token-2","renewable":true,"lease_duration":60}}`))
+		case "/v1/secret/data/database/mysql":
+			if got := r.Header.Get("X-Vault-Token"); got != "token-2" {
+				t.Fatalf("read X-Vault-Token = %q, want token-2", got)
+			}
+
+			_, _ = w.Write([]byte(`{"data":{"data":{"password":"renewed-secret"}}}`))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider := &VaultProvider{}
+	if err := provider.Initialize(map[string]string{
+		"VAULT_ADDR":        server.URL,
+		"VAULT_AUTH_METHOD": "jwt",
+		"VAULT_JWT_ROLE":    "swarm-external-secrets",
+		"VAULT_JWT":         "test.jwt.token",
+		"VAULT_MOUNT_PATH":  "secret",
+	}); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	defer func() { _ = provider.Close() }()
+
+	select {
+	case <-renewCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("token was not renewed")
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	req := secrets.Request{
+		SecretName: "fallback",
+		SecretLabels: map[string]string{
+			"vault_path":  "database/mysql",
+			"vault_field": "password",
+		},
+	}
+	got, err := provider.GetSecret(t.Context(), &SecretInfo{
+		DockerSecretName: req.SecretName,
+		SecretPath:       provider.BuildSecretPath(req),
+		SecretField:      req.SecretLabels[provider.GetSecretFieldLabel()],
+		Provider:         provider.GetProviderName(),
+		Labels:           req.SecretLabels,
+	})
+	if err != nil {
+		t.Fatalf("GetSecret() error = %v", err)
+	}
+	if string(got) != "renewed-secret" {
+		t.Fatalf("GetSecret() = %q, want renewed-secret", string(got))
+	}
+}
+
+func TestVaultProvider_AuthenticateWithJWT_CustomAuthPathAndFilePrecedence(t *testing.T) {
+	var loginRequest struct {
+		Role string `json:"role"`
+		JWT  string `json:"jwt"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/auth/oidc/login" {
+			t.Fatalf("jwt login path = %s, want /v1/auth/oidc/login", r.URL.Path)
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&loginRequest); err != nil {
+			t.Fatalf("decode jwt login request: %v", err)
+		}
+
+		_, _ = w.Write([]byte(`{"auth":{"client_token":"vault-client-token"}}`))
+	}))
+	defer server.Close()
+
+	jwtFile := filepath.Join(t.TempDir(), "jwt")
+	if err := os.WriteFile(jwtFile, []byte("file.jwt.token\n"), 0o600); err != nil {
+		t.Fatalf("write jwt file: %v", err)
+	}
+
+	provider := &VaultProvider{}
+	if err := provider.Initialize(map[string]string{
+		"VAULT_ADDR":          server.URL,
+		"VAULT_AUTH_METHOD":   "jwt",
+		"VAULT_JWT_ROLE":      "swarm-external-secrets",
+		"VAULT_JWT":           "env.jwt.token",
+		"VAULT_JWT_FILE":      jwtFile,
+		"VAULT_JWT_AUTH_PATH": "/oidc/",
+	}); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	defer func() { _ = provider.Close() }()
+
+	if loginRequest.JWT != "file.jwt.token" {
+		t.Fatalf("login jwt = %q, want file.jwt.token", loginRequest.JWT)
+	}
+}
+
+func TestVaultProvider_AuthenticateWithJWT_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr string
+	}{
+		{
+			name: "missing role",
+			config: map[string]string{
+				"VAULT_AUTH_METHOD": "jwt",
+				"VAULT_JWT":         "test.jwt.token",
+			},
+			wantErr: "VAULT_JWT_ROLE is required for jwt authentication",
+		},
+		{
+			name: "missing jwt",
+			config: map[string]string{
+				"VAULT_AUTH_METHOD": "jwt",
+				"VAULT_JWT_ROLE":    "swarm-external-secrets",
+			},
+			wantErr: "VAULT_JWT or VAULT_JWT_FILE is required for jwt authentication",
+		},
+		{
+			name: "empty jwt file",
+			config: map[string]string{
+				"VAULT_AUTH_METHOD": "jwt",
+				"VAULT_JWT_ROLE":    "swarm-external-secrets",
+				"VAULT_JWT_FILE":    emptyFile(t),
+			},
+			wantErr: "VAULT_JWT_FILE is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &VaultProvider{}
+			err := provider.Initialize(tt.config)
+			if err == nil {
+				t.Fatal("Initialize() error = nil, want error")
+			}
+
+			if got := err.Error(); got != "failed to authenticate with vault: "+tt.wantErr {
+				t.Fatalf("Initialize() error = %q, want %q", got, "failed to authenticate with vault: "+tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVaultProvider_AuthenticateWithJWT_LoginFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/auth/jwt/login" {
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+
+		http.Error(w, "permission denied", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	provider := &VaultProvider{}
+	err := provider.Initialize(map[string]string{
+		"VAULT_ADDR":        server.URL,
+		"VAULT_AUTH_METHOD": "jwt",
+		"VAULT_JWT_ROLE":    "swarm-external-secrets",
+		"VAULT_JWT":         "test.jwt.token",
+	})
+	if err == nil {
+		t.Fatal("Initialize() error = nil, want error")
+	}
+
+	if got := err.Error(); got != "failed to authenticate with vault: jwt authentication failed: Error making API request.\n\nURL: PUT "+server.URL+"/v1/auth/jwt/login\nCode: 403. Errors:\n\n* permission denied" {
+		if !containsAll(got, "failed to authenticate with vault", "jwt authentication failed", "403", "permission denied") {
+			t.Fatalf("Initialize() error = %q", got)
+		}
+	}
+}
+
+func containsAll(s string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(s, part) {
+			return false
+		}
+	}
+	return true
+}
+
+func emptyFile(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "empty-jwt")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("write empty jwt file: %v", err)
+	}
+
+	return path
+}

--- a/scripts/tests/smoke-test-vault-jwt.sh
+++ b/scripts/tests/smoke-test-vault-jwt.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+
+set -ex
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(realpath -- "${SCRIPT_DIR}/../..")"
+
+# shellcheck source=smoke-test-helper.sh
+source "${SCRIPT_DIR}/smoke-test-helper.sh"
+
+VAULT_CONTAINER="smoke-vault-jwt"
+VAULT_ROOT_TOKEN="smoke-root-token"
+VAULT_ADDR="http://127.0.0.1:8200"
+STACK_NAME="smoke-vault-jwt"
+SECRET_NAME="smoke_secret"
+SECRET_PATH="database/mysql"
+SECRET_FIELD="password"
+SECRET_VALUE="vault-jwt-smoke-pass-v1"
+COMPOSE_FILE="${SCRIPT_DIR}/smoke-vault-compose.yml"
+POLICY_FILE="${REPO_ROOT}/vault_conf/admin.hcl"
+JWT_WORKDIR="$(mktemp -d)"
+JWT_ROLE="swarm-external-secrets"
+JWT_TOKEN_TTL="10s"
+JWT_TOKEN_MAX_TTL="25s"
+RENEWAL_WAIT_SECONDS=45
+LOG_EXPORT_DIR="${REPO_ROOT}/.tmp/smoke-vault-jwt"
+PLUGIN_LOG_PATH="/run/swarm-external-secrets/plugin.log"
+PLUGIN_LOG_EXPORT="${LOG_EXPORT_DIR}/plugin.log"
+DAEMON_LOG_EXPORT="${LOG_EXPORT_DIR}/docker-daemon.log"
+EXIT_CODE=0
+
+base64url() {
+    openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+generate_local_jwt() {
+    openssl genrsa -out "${JWT_WORKDIR}/jwt-private.pem" 2048 >/dev/null 2>&1
+    openssl rsa -in "${JWT_WORKDIR}/jwt-private.pem" -pubout -out "${JWT_WORKDIR}/jwt-public.pem" >/dev/null 2>&1
+
+    local header payload unsigned signature
+    header="$(printf '{"alg":"RS256","typ":"JWT"}' | base64url)"
+    payload="$(printf '{"iss":"swarm-external-secrets-local","sub":"swarm-external-secrets","aud":"vault"}' | base64url)"
+    unsigned="${header}.${payload}"
+    signature="$(printf '%s' "${unsigned}" | openssl dgst -sha256 -sign "${JWT_WORKDIR}/jwt-private.pem" -binary | base64url)"
+    printf '%s.%s\n' "${unsigned}" "${signature}" > "${JWT_WORKDIR}/workload.jwt"
+}
+
+prepare_plugin_log_path() {
+    mkdir -p "${LOG_EXPORT_DIR}"
+    : > "${PLUGIN_LOG_EXPORT}"
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        info "Preparing plugin log path inside Docker Desktop VM..."
+        docker run --rm --privileged --pid=host justincormack/nsenter1 \
+            sh -lc "mkdir -p /run/swarm-external-secrets && touch '${PLUGIN_LOG_PATH}' && chmod -R 777 /run/swarm-external-secrets"
+        return
+    fi
+
+    info "Preparing plugin log path on Linux host..."
+    if [ "$(id -u)" -eq 0 ]; then
+        mkdir -p /run/swarm-external-secrets
+        touch "${PLUGIN_LOG_PATH}"
+        chmod -R 777 /run/swarm-external-secrets
+    else
+        sudo mkdir -p /run/swarm-external-secrets
+        sudo touch "${PLUGIN_LOG_PATH}"
+        sudo chmod -R 777 /run/swarm-external-secrets
+    fi
+}
+
+export_plugin_logs() {
+    mkdir -p "${LOG_EXPORT_DIR}"
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        docker run --rm --privileged --pid=host justincormack/nsenter1 \
+            sh -lc "cat '${PLUGIN_LOG_PATH}' 2>/dev/null" > "${PLUGIN_LOG_EXPORT}" || true
+    elif [ -r "${PLUGIN_LOG_PATH}" ]; then
+        cp "${PLUGIN_LOG_PATH}" "${PLUGIN_LOG_EXPORT}" || true
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo cp "${PLUGIN_LOG_PATH}" "${PLUGIN_LOG_EXPORT}" 2>/dev/null || true
+        sudo chown "$(id -u):$(id -g)" "${PLUGIN_LOG_EXPORT}" 2>/dev/null || true
+    fi
+
+    docker_daemon_logs > "${DAEMON_LOG_EXPORT}" || true
+    info "Exported plugin logs to: ${PLUGIN_LOG_EXPORT}"
+    info "Exported Docker daemon logs to: ${DAEMON_LOG_EXPORT}"
+}
+
+assert_log_contains_any() {
+    local description="$1"
+    shift
+
+    export_plugin_logs
+    local logs
+    logs="$(cat "${PLUGIN_LOG_EXPORT}" "${DAEMON_LOG_EXPORT}" 2>/dev/null || true)"
+
+    for expected in "$@"; do
+        if echo "${logs}" | grep -Fq "${expected}"; then
+            success "${description}: found '${expected}'"
+            return
+        fi
+    done
+
+    die "${description}: expected one of [$*]. See exported logs in ${LOG_EXPORT_DIR}"
+}
+
+cleanup() {
+    EXIT_CODE=$?
+    set +e
+    echo -e "${RED}Running Vault JWT smoke test cleanup...${DEF}"
+    export_plugin_logs
+    remove_stack "${STACK_NAME}"
+    docker secret rm "${SECRET_NAME}" 2>/dev/null || true
+    docker stop "${VAULT_CONTAINER}" 2>/dev/null || true
+    docker rm   "${VAULT_CONTAINER}" 2>/dev/null || true
+    rm -rf "${JWT_WORKDIR}"
+    remove_plugin
+    exit "${EXIT_CODE}"
+}
+trap cleanup EXIT
+
+prepare_plugin_log_path
+
+info "Starting HashiCorp Vault dev container..."
+docker run -d \
+    --name "${VAULT_CONTAINER}" \
+    -p 8200:8200 \
+    -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_ROOT_TOKEN}" \
+    hashicorp/vault:latest server -dev
+
+info "Waiting for Vault to be ready..."
+elapsed=0
+until docker exec "${VAULT_CONTAINER}" vault status -address="${VAULT_ADDR}" &>/dev/null; do
+    sleep 2
+    elapsed=$((elapsed + 2))
+    [[ "${elapsed}" -lt 30 ]] || die "Vault did not become ready within 30s."
+done
+success "Vault is ready."
+
+info "Applying policy to Vault..."
+docker cp "${POLICY_FILE}" "${VAULT_CONTAINER}:/tmp/admin.hcl"
+docker exec "${VAULT_CONTAINER}" sh -lc 'cat >>/tmp/admin.hcl <<EOF
+
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+EOF'
+docker exec "${VAULT_CONTAINER}" \
+    env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
+    vault policy write smoke-policy /tmp/admin.hcl
+success "Policy applied."
+
+info "Writing test secret to Vault..."
+docker exec "${VAULT_CONTAINER}" \
+    env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
+    vault kv put \
+    "secret/${SECRET_PATH}" \
+    "${SECRET_FIELD}=${SECRET_VALUE}"
+success "Secret written."
+
+info "Generating local JWT signing keys and signed JWT..."
+generate_local_jwt
+docker cp "${JWT_WORKDIR}/jwt-public.pem" "${VAULT_CONTAINER}:/tmp/jwt-public.pem"
+
+info "Configuring Vault JWT auth..."
+docker exec "${VAULT_CONTAINER}" \
+    env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
+    vault auth enable jwt
+docker exec "${VAULT_CONTAINER}" \
+    env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
+    vault write auth/jwt/config \
+        jwt_validation_pubkeys=@/tmp/jwt-public.pem \
+        bound_issuer="swarm-external-secrets-local"
+docker exec "${VAULT_CONTAINER}" \
+    env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
+    vault write "auth/jwt/role/${JWT_ROLE}" \
+        role_type="jwt" \
+        user_claim="sub" \
+        bound_audiences="vault" \
+        bound_subject="swarm-external-secrets" \
+        policies="smoke-policy" \
+        ttl="${JWT_TOKEN_TTL}" \
+        max_ttl="${JWT_TOKEN_MAX_TTL}"
+success "Vault JWT auth configured."
+
+WORKLOAD_JWT="$(tr -d '\n' < "${JWT_WORKDIR}/workload.jwt")"
+
+info "Building plugin and configuring JWT auth..."
+build_plugin
+
+docker plugin set "${PLUGIN_NAME}" \
+    SECRETS_PROVIDER="vault" \
+    VAULT_ADDR="${VAULT_ADDR}" \
+    VAULT_AUTH_METHOD="jwt" \
+    VAULT_JWT_ROLE="${JWT_ROLE}" \
+    VAULT_JWT="${WORKLOAD_JWT}" \
+    VAULT_JWT_AUTH_PATH="jwt" \
+    VAULT_MOUNT_PATH="secret" \
+    ENABLE_ROTATION="false" \
+    ENABLE_MONITORING="false" \
+    LOG_LEVEL="debug" \
+    PLUGIN_LOG_PATH="${PLUGIN_LOG_PATH}"
+success "Plugin configured with Vault JWT auth."
+
+info "Enabling plugin..."
+enable_plugin
+
+info "Deploying swarm stack..."
+deploy_stack "${COMPOSE_FILE}" "${STACK_NAME}" 60
+
+info "Verifying secret value matches expected password..."
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE}" 60
+
+info "Waiting ${RENEWAL_WAIT_SECONDS}s for JWT token renewal and max-TTL re-auth paths..."
+sleep "${RENEWAL_WAIT_SECONDS}"
+export_plugin_logs
+
+assert_log_contains_any \
+    "JWT renewal path" \
+    "Successfully renewed vault token"
+
+assert_log_contains_any \
+    "JWT re-auth fallback path" \
+    "Renewing vault token failed, attempting re-authentication" \
+    "Successfully re-authenticated with vault"
+
+info "Re-deploying stack to prove reads still work after original token max TTL..."
+remove_stack "${STACK_NAME}"
+docker secret rm "${SECRET_NAME}" 2>/dev/null || true
+deploy_stack "${COMPOSE_FILE}" "${STACK_NAME}" 60
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE}" 60
+
+success "Vault JWT smoke test PASSED"

--- a/scripts/tests/smoke-test-vault-jwt.sh
+++ b/scripts/tests/smoke-test-vault-jwt.sh
@@ -49,7 +49,7 @@ prepare_plugin_log_path() {
     mkdir -p "${LOG_EXPORT_DIR}"
     : > "${PLUGIN_LOG_EXPORT}"
 
-    if [ "$(uname -s)" = "Darwin" ]; then
+    if [[ "$(uname -s)" = "Darwin" ]]; then
         info "Preparing plugin log path inside Docker Desktop VM..."
         docker run --rm --privileged --pid=host justincormack/nsenter1 \
             sh -lc "mkdir -p /run/swarm-external-secrets && touch '${PLUGIN_LOG_PATH}' && chmod -R 777 /run/swarm-external-secrets"
@@ -57,24 +57,22 @@ prepare_plugin_log_path() {
     fi
 
     info "Preparing plugin log path on Linux host..."
-    if [ "$(id -u)" -eq 0 ]; then
+    if [[ "$(id -u)" -eq 0 ]]; then
         mkdir -p /run/swarm-external-secrets
         touch "${PLUGIN_LOG_PATH}"
-        chmod -R 777 /run/swarm-external-secrets
     else
         sudo mkdir -p /run/swarm-external-secrets
         sudo touch "${PLUGIN_LOG_PATH}"
-        sudo chmod -R 777 /run/swarm-external-secrets
     fi
 }
 
 export_plugin_logs() {
     mkdir -p "${LOG_EXPORT_DIR}"
 
-    if [ "$(uname -s)" = "Darwin" ]; then
+    if [[ "$(uname -s)" = "Darwin" ]]; then
         docker run --rm --privileged --pid=host justincormack/nsenter1 \
             sh -lc "cat '${PLUGIN_LOG_PATH}' 2>/dev/null" > "${PLUGIN_LOG_EXPORT}" || true
-    elif [ -r "${PLUGIN_LOG_PATH}" ]; then
+    elif [[ -r "${PLUGIN_LOG_PATH}" ]]; then
         cp "${PLUGIN_LOG_PATH}" "${PLUGIN_LOG_EXPORT}" || true
     elif command -v sudo >/dev/null 2>&1; then
         sudo cp "${PLUGIN_LOG_PATH}" "${PLUGIN_LOG_EXPORT}" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Extract Vault and OpenBao providers into a shared `vaultcompat` backend (client init, auth, secret retrieval via unified backend interface)
- Add JWT and AppRole login support with token renewal and re-authentication
- Add secret path building/extraction utilities and client read/write interface
- Add JWT auth tests and smoke test script; align gosec config

Part of the `alpha/provider-integration` stack (2/3). Depends on #182.