### PR TITLE
feat: add GCP Secret Manager smoke test with floci-gcp emulator

### DIFF
--- a/.github/workflows/gcp-floci-tests.yml
+++ b/.github/workflows/gcp-floci-tests.yml
@@ -1,0 +1,34 @@
+name: GCP Floci Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, alpha/provider-integration]
+
+jobs:
+  gcp-floci-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GCP_PROJECT_ID: floci-local
+      SECRET_MANAGER_EMULATOR_HOST: localhost:4588
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Init Docker Swarm
+        run: docker swarm init
+
+      # floci-gcp is started by the smoke test itself. The test uses curl
+      # against the Secret Manager REST API; no gcloud CLI is required.
+      - name: Run GCP Secret Manager smoke test
+        run: bash scripts/tests/smoke-test-gcp.sh
+
+      - name: floci-gcp logs
+        if: failure()
+        run: docker logs smoke-floci-gcp || true

--- a/config.json
+++ b/config.json
@@ -234,6 +234,16 @@
       "settable": ["value"]
     },
     {
+      "name": "SECRET_MANAGER_EMULATOR_HOST",
+      "description": "GCP Secret Manager emulator host:port (floci-gcp, e.g. localhost:4588)",
+      "settable": ["value"]
+    },
+    {
+      "name": "GCP_ENDPOINT",
+      "description": "Optional GCP Secret Manager endpoint override (alias for SECRET_MANAGER_EMULATOR_HOST)",
+      "settable": ["value"]
+    },
+    {
       "name": "ENABLE_MONITORING",
       "description": "Enable Monitoring secret rotation (true/false) default true",
       "settable": ["value"]

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/openbao/openbao/api/v2 v2.3.1
 	github.com/sirupsen/logrus v1.9.3
 	google.golang.org/api v0.237.0
+	google.golang.org/grpc v1.73.0
 )
 
 require (
@@ -97,7 +98,6 @@ require (
 	google.golang.org/genproto v0.0.0-20250505200425-f936aa4a68b2 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
-	google.golang.org/grpc v1.73.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 )

--- a/providers/factory.go
+++ b/providers/factory.go
@@ -55,7 +55,7 @@ func GetProviderInfo(providerType string) (map[string]string, error) {
 		info["name"] = "GCP Secret Manager"
 		info["description"] = "Google Cloud Platform Secret Manager"
 		info["auth_methods"] = "service account, ADC"
-		info["env_vars"] = "GCP_PROJECT_ID, GOOGLE_APPLICATION_CREDENTIALS, GCP_CREDENTIALS_JSON"
+		info["env_vars"] = "GCP_PROJECT_ID, GOOGLE_APPLICATION_CREDENTIALS, GCP_CREDENTIALS_JSON, SECRET_MANAGER_EMULATOR_HOST, GCP_ENDPOINT"
 
 	case "azure", "azure-key-vault":
 		info["name"] = "Azure Key Vault"

--- a/providers/gcp.go
+++ b/providers/gcp.go
@@ -10,6 +10,8 @@ import (
 	"github.com/docker/go-plugins-helpers/secrets"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/sugar-org/swarm-external-secrets/internal/utils"
 )
@@ -25,6 +27,9 @@ type GCPConfig struct {
 	ProjectID       string
 	CredentialsPath string
 	CredentialsJSON string
+	// EmulatorHost is host:port for a local emulator (floci-gcp). When set,
+	// the client skips Google auth and dials plaintext gRPC.
+	EmulatorHost string
 }
 
 // Initialize sets up the GCP provider with the given configuration
@@ -33,6 +38,7 @@ func (g *GCPProvider) Initialize(config map[string]string) error {
 		ProjectID:       utils.GetConfigOrDefault(config, "GCP_PROJECT_ID", ""),
 		CredentialsPath: utils.GetConfigOrDefault(config, "GOOGLE_APPLICATION_CREDENTIALS", ""),
 		CredentialsJSON: config["GCP_CREDENTIALS_JSON"],
+		EmulatorHost:    emulatorHostFromConfig(config),
 	}
 
 	if g.config.ProjectID == "" {
@@ -43,12 +49,22 @@ func (g *GCPProvider) Initialize(config map[string]string) error {
 	var client *secretmanager.Client
 	var err error
 
-	// Support multiple authentication strategies
-	if g.config.CredentialsJSON != "" {
+	switch {
+	case g.config.EmulatorHost != "":
+		// floci-gcp (and the official emulator) speak plaintext gRPC and do not
+		// validate credentials. SECRET_MANAGER_EMULATOR_HOST is the documented env.
+		log.Infof("Connecting to GCP Secret Manager emulator at %s", g.config.EmulatorHost)
+		client, err = secretmanager.NewClient(ctx,
+			option.WithEndpoint(g.config.EmulatorHost),
+			option.WithoutAuthentication(),
+			option.WithTelemetryDisabled(),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		)
+	case g.config.CredentialsJSON != "":
 		client, err = secretmanager.NewClient(ctx, option.WithCredentialsJSON([]byte(g.config.CredentialsJSON)))
-	} else if g.config.CredentialsPath != "" {
+	case g.config.CredentialsPath != "":
 		client, err = secretmanager.NewClient(ctx, option.WithCredentialsFile(g.config.CredentialsPath))
-	} else {
+	default:
 		// Fallback to Application Default Credentials (ADC)
 		client, err = secretmanager.NewClient(ctx)
 	}
@@ -60,6 +76,16 @@ func (g *GCPProvider) Initialize(config map[string]string) error {
 
 	log.Infof("Successfully initialized GCP Secret Manager provider for project: %s", g.config.ProjectID)
 	return nil
+}
+
+func emulatorHostFromConfig(config map[string]string) string {
+	host := utils.GetConfigOrDefault(config, "SECRET_MANAGER_EMULATOR_HOST", "")
+	if host == "" {
+		host = utils.GetConfigOrDefault(config, "GCP_ENDPOINT", "")
+	}
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.TrimPrefix(host, "https://")
+	return host
 }
 
 // GetSecret retrieves a secret value from GCP Secret Manager

--- a/providers/gcp_test.go
+++ b/providers/gcp_test.go
@@ -1,0 +1,39 @@
+package providers
+
+import (
+	"testing"
+)
+
+func TestGCPProvider_InitializeEmulatorHost(t *testing.T) {
+	provider := &GCPProvider{}
+	err := provider.Initialize(map[string]string{
+		"GCP_PROJECT_ID":               "floci-local",
+		"SECRET_MANAGER_EMULATOR_HOST": "localhost:4588",
+	})
+	if err != nil {
+		t.Fatalf("Initialize() with SECRET_MANAGER_EMULATOR_HOST error = %v", err)
+	}
+	if provider.config.EmulatorHost != "localhost:4588" {
+		t.Fatalf("EmulatorHost = %q, want localhost:4588", provider.config.EmulatorHost)
+	}
+	if err := provider.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestGCPProvider_InitializeEmulatorHostStripsScheme(t *testing.T) {
+	provider := &GCPProvider{}
+	err := provider.Initialize(map[string]string{
+		"GCP_PROJECT_ID": "floci-local",
+		"GCP_ENDPOINT":   "http://localhost:4588",
+	})
+	if err != nil {
+		t.Fatalf("Initialize() with GCP_ENDPOINT error = %v", err)
+	}
+	if provider.config.EmulatorHost != "localhost:4588" {
+		t.Fatalf("EmulatorHost = %q, want localhost:4588", provider.config.EmulatorHost)
+	}
+	if err := provider.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}

--- a/scripts/tests/smoke-gcp-compose.yml
+++ b/scripts/tests/smoke-gcp-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  app:
+    image: busybox:latest
+    command: >
+      sh -c "
+        while true; do
+          echo 'Current secret:'
+          cat /run/secrets/smoke_secret
+          sleep 2
+        done
+      "
+    secrets:
+      - smoke_secret
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+
+secrets:
+  smoke_secret:
+    driver: swarm-external-secrets:latest
+    labels:
+      gcp_secret_name: "smoke-test-secret"
+      gcp_field: "password"
+
+networks:
+  default:
+    driver: overlay

--- a/scripts/tests/smoke-test-gcp.sh
+++ b/scripts/tests/smoke-test-gcp.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -ex
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="${GITHUB_WORKSPACE:-$(realpath -- "${SCRIPT_DIR}/../..")}"
+# shellcheck source=smoke-test-helper.sh
+source "${SCRIPT_DIR}/smoke-test-helper.sh"
+
+# Configuration
+# floci-gcp is a lightweight open-source GCP emulator (https://floci.io/floci-gcp/).
+# Secret Manager is on port 4588 (gRPC + REST), needs no auth token or license.
+FLOCI_CONTAINER="smoke-floci-gcp"
+FLOCI_IMAGE="floci/floci-gcp:latest"
+GCP_ENDPOINT="http://localhost:4588"
+GCP_EMULATOR_HOST="localhost:4588"
+GCP_PROJECT_ID="floci-local"
+STACK_NAME="smoke-gcp"
+SECRET_NAME="smoke_secret"
+SECRET_PATH="smoke-test-secret"
+SECRET_FIELD="password"
+SECRET_VALUE="gcp-smoke-pass-v1"
+SECRET_VALUE_ROTATED="gcp-smoke-pass-v2"
+COMPOSE_FILE="${SCRIPT_DIR}/smoke-gcp-compose.yml"
+SECRET_PARENT="projects/${GCP_PROJECT_ID}/secrets/${SECRET_PATH}"
+
+# Helper to call floci-gcp Secret Manager REST.
+sm_api() {
+    curl -sf \
+        -H "Content-Type: application/json" \
+        "$@"
+}
+
+json_payload() {
+    local value="$1"
+    printf '{"%s":"%s"}' "${SECRET_FIELD}" "${value}" | base64 -w0 2>/dev/null || printf '{"%s":"%s"}' "${SECRET_FIELD}" "${value}" | base64
+}
+
+# Cleanup trap
+cleanup() {
+    echo -e "${RED}Running GCP Secret Manager smoke test cleanup...${DEF}"
+    remove_stack "${STACK_NAME}"
+    docker secret rm "${SECRET_NAME}" 2>/dev/null || true
+    if [[ -n "${FLOCI_CONTAINER}" ]]; then
+        echo -e "${RED}floci-gcp logs:${DEF}"
+        docker logs "${FLOCI_CONTAINER}" 2>/dev/null || true
+        docker stop "${FLOCI_CONTAINER}" 2>/dev/null || true
+        docker rm   "${FLOCI_CONTAINER}" 2>/dev/null || true
+    fi
+    remove_plugin
+}
+trap cleanup EXIT
+
+command -v curl >/dev/null 2>&1 || die "curl is required to run the GCP Secret Manager smoke test."
+
+# Start floci-gcp container (skip if an emulator is already serving on 4588)
+if sm_api "${GCP_ENDPOINT}/v1/projects/${GCP_PROJECT_ID}/secrets" >/dev/null 2>&1; then
+    info "GCP emulator already running on 4588, skipping container start."
+    FLOCI_CONTAINER=""
+else
+    info "Starting floci-gcp emulator container..."
+    docker run -d \
+        --name "${FLOCI_CONTAINER}" \
+        -p 4588:4588 \
+        "${FLOCI_IMAGE}"
+fi
+
+info "Waiting for floci-gcp to be ready..."
+elapsed=0
+until sm_api "${GCP_ENDPOINT}/v1/projects/${GCP_PROJECT_ID}/secrets" >/dev/null 2>&1; do
+    sleep 2
+    elapsed=$((elapsed + 2))
+    [[ "${elapsed}" -lt 60 ]] || die "floci-gcp did not become ready within 60s."
+done
+success "floci-gcp is ready."
+
+info "Creating test secret in floci-gcp Secret Manager..."
+sm_api -X POST \
+    "${GCP_ENDPOINT}/v1/projects/${GCP_PROJECT_ID}/secrets?secretId=${SECRET_PATH}" \
+    -d '{"replication":{"automatic":{}}}' >/dev/null || true
+sm_api -X POST \
+    "${GCP_ENDPOINT}/v1/${SECRET_PARENT}:addVersion" \
+    -d "{\"payload\":{\"data\":\"$(json_payload "${SECRET_VALUE}")\"}}" >/dev/null
+success "Secret written: ${SECRET_PATH}"
+
+info "Building plugin and setting GCP Secret Manager config..."
+build_plugin
+docker plugin disable "${PLUGIN_NAME}" --force 2>/dev/null || true
+docker plugin set "${PLUGIN_NAME}" \
+    SECRETS_PROVIDER="gcp" \
+    GCP_PROJECT_ID="${GCP_PROJECT_ID}" \
+    SECRET_MANAGER_EMULATOR_HOST="${GCP_EMULATOR_HOST}" \
+    ENABLE_ROTATION="true" \
+    ROTATION_INTERVAL="10s" \
+    ENABLE_MONITORING="false"
+
+success "Plugin configured with GCP Secret Manager settings."
+
+info "Enabling plugin..."
+enable_plugin
+
+info "Deploying swarm stack..."
+deploy_stack "${COMPOSE_FILE}" "${STACK_NAME}" 60
+
+info "Logging service output..."
+sleep 10
+log_stack "${STACK_NAME}" "app"
+assert_no_sensitive_rotation_metadata_logs
+
+info "Verifying secret value matches expected password..."
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE}" 60
+
+info "Rotating secret in GCP Secret Manager..."
+sm_api -X POST \
+    "${GCP_ENDPOINT}/v1/${SECRET_PARENT}:addVersion" \
+    -d "{\"payload\":{\"data\":\"$(json_payload "${SECRET_VALUE_ROTATED}")\"}}" >/dev/null
+success "Secret rotated to: ${SECRET_VALUE_ROTATED}"
+
+info "Waiting for plugin rotation interval..."
+sleep 30
+assert_no_sensitive_rotation_metadata_logs
+
+info "Logging service output after rotation..."
+log_stack "${STACK_NAME}" "app"
+
+info "Verifying rotated secret value..."
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE_ROTATED}" 180
+
+success "GCP Secret Manager smoke test PASSED"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation
- [x] CI

## Mention the secrets provider

GCP Secret Manager

## Description

Stacked on #187 (`feat/azure-floci-smoke-test`). Same Floci smoke-test pattern, for GCP Secret Manager against [floci-gcp](https://floci.io/floci-gcp/services/secret-manager/).

- Provider: when `SECRET_MANAGER_EMULATOR_HOST` (or `GCP_ENDPOINT`) is set, skip ADC and dial plaintext gRPC with no auth
- Plugin env vars in `config.json`
- `scripts/tests/smoke-test-gcp.sh` starts floci-gcp on `:4588`, seeds a JSON secret via REST, deploys a Swarm stack, then rotates and re-checks
- CI: `.github/workflows/gcp-floci-tests.yml`

Default emulator project is `floci-local`. No GCP account or service-account key is required.

## Commands & Configuration to test

```bash
docker swarm init    # if needed
bash scripts/tests/smoke-test-gcp.sh
```

Plugin settings applied by the smoke test:

```bash
docker plugin set swarm-external-secrets:latest \
  SECRETS_PROVIDER="gcp" \
  GCP_PROJECT_ID="floci-local" \
  SECRET_MANAGER_EMULATOR_HOST="localhost:4588" \
  ENABLE_ROTATION="true" \
  ROTATION_INTERVAL="10s"
```

```bash
go test ./providers/ -run TestGCPProvider_
```

## Screenshots & Logs

The `gcp-floci-tests` workflow on this PR is the CI check. REST create/addVersion/access against `floci/floci-gcp:latest` was verified locally before opening.

## Related Tickets & Documents

- Stacked on #187
- Related Issue #40

## Was this PR authored or co-authored using generative AI tooling?

Yes.

Made with [Cursor](https://cursor.com)