### PR TITLE
test: add OCI Vault Floci smoke tests

### DIFF
--- a/.github/workflows/oci-floci-tests.yml
+++ b/.github/workflows/oci-floci-tests.yml
@@ -59,7 +59,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Init Docker Swarm
         run: docker swarm init

--- a/.github/workflows/oci-floci-tests.yml
+++ b/.github/workflows/oci-floci-tests.yml
@@ -1,0 +1,36 @@
+name: OCI Floci Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, alpha/provider-integration, feat/oci-provider]
+
+jobs:
+  oci-floci-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      OCI_ENDPOINT: http://localhost:4599
+      OCI_REGION: us-ashburn-1
+      OCI_TENANCY_OCID: ocid1.tenancy.oc1..flocilocaltenancy0000000000000000000000000000000000000000
+      OCI_AUTH_METHOD: api_key
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Init Docker Swarm
+        run: docker swarm init
+
+      # floci-oci is started by the smoke test itself. The test uses curl
+      # against the Vault/KMS/Secrets REST APIs; the OCI CLI is not required.
+      - name: Run OCI Vault smoke test
+        run: bash scripts/tests/smoke-test-oci.sh
+
+      - name: floci-oci logs
+        if: failure()
+        run: docker logs smoke-floci-oci || true

--- a/.github/workflows/oci-floci-tests.yml
+++ b/.github/workflows/oci-floci-tests.yml
@@ -6,7 +6,45 @@ on:
     branches: [main, alpha/provider-integration, feat/oci-provider]
 
 jobs:
-  oci-floci-tests:
+  # AWS-style: start the emulator and exercise Vault + KMS crypto + secret
+  # bundles with curl (no plugin build). See
+  # https://floci.io/floci-oci/services/kms-vault/
+  oci-kms-vault-roundtrip:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      OCI_ENDPOINT: http://localhost:4599
+      OCI_TENANCY_OCID: ocid1.tenancy.oc1..flocilocaltenancy0000000000000000000000000000000000000000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Start floci-oci
+        run: |
+          docker compose -f scripts/tests/floci-oci-compose.yml up -d
+          elapsed=0
+          until curl -sf http://localhost:4599/_floci-oci/health >/dev/null 2>&1; do
+            sleep 2
+            elapsed=$((elapsed + 2))
+            if [[ "${elapsed}" -ge 30 ]]; then
+              echo "floci-oci did not become healthy within 30s"
+              docker compose -f scripts/tests/floci-oci-compose.yml logs
+              exit 1
+            fi
+          done
+          echo "floci-oci is ready."
+
+      - name: Verify OCI KMS Vault + Secrets roundtrip
+        run: bash scripts/tests/floci-oci-roundtrip.sh
+
+      - name: floci-oci logs
+        if: failure()
+        run: docker compose -f scripts/tests/floci-oci-compose.yml logs
+
+  # Azure/GCP-style: Swarm plugin smoke against the same emulator.
+  oci-floci-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -26,8 +64,6 @@ jobs:
       - name: Init Docker Swarm
         run: docker swarm init
 
-      # floci-oci is started by the smoke test itself. The test uses curl
-      # against the Vault/KMS/Secrets REST APIs; the OCI CLI is not required.
       - name: Run OCI Vault smoke test
         run: bash scripts/tests/smoke-test-oci.sh
 

--- a/scripts/tests/README-floci.md
+++ b/scripts/tests/README-floci.md
@@ -1,4 +1,6 @@
-# Floci AWS emulator checks
+# Floci emulator checks
+
+## AWS
 
 The `aws-floci-tests` workflow (`.github/workflows/aws-floci-tests.yml`) uses [Floci](https://github.com/floci-io/floci) as a lightweight AWS emulator to verify the AWS KMS + AWS Secrets Manager flow used by KMS secret transformation (`internal/secrettransform/aws_kms.go`) — the same flow the full Swarm smoke test in `smoke-test-awssm.sh` exercises end to end.
 
@@ -10,7 +12,7 @@ The check (`scripts/tests/floci-kms-roundtrip.sh`):
 4. fetches the secret back and decrypts it with KMS (without a `KeyId`, exactly like the plugin's transformer) and verifies the plaintext
 5. rotates the value with `put-secret-value` and verifies again
 
-## Run locally
+## Run locally (AWS)
 
 Prerequisites: Docker, the `aws` CLI (v2), and `jq`.
 
@@ -26,8 +28,27 @@ Run the check (reads `AWS_ENDPOINT_URL`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS
 bash scripts/tests/floci-kms-roundtrip.sh
 ```
 
+## OCI
+
+The `oci-floci-tests` workflow (`.github/workflows/oci-floci-tests.yml`) uses [floci-oci](https://floci.io/floci-oci/) on port 4599. The smoke test (`scripts/tests/smoke-test-oci.sh`):
+
+1. starts `floci/floci-oci` unless `http://localhost:4599/_floci-oci/health` already succeeds
+2. creates a vault, AES key, and secret (JSON `password` field)
+3. fetches the secret bundle by name over REST
+4. builds the plugin with `OCI_ENDPOINT=http://localhost:4599` and a throwaway API key
+5. deploys a Swarm stack and verifies the mounted secret, including after rotation
+
+```bash
+bash scripts/tests/smoke-test-oci.sh
+```
+
+Health: `curl http://localhost:4599/_floci-oci/health`  
+Vault/KMS/Secrets API notes: https://floci.io/floci-oci/services/kms-vault/
+
 ## References
 
 - Floci repository: https://github.com/floci-io/floci
-- Docker image: `floci/floci:1.6.0@sha256:eab36252ea43a4a73928423f0372219052c5c6f87207f6c4754db14b91d6ed30`
+- floci-oci repository: https://github.com/floci-io/floci-oci
+- Docker image (AWS): `floci/floci:1.6.0@sha256:eab36252ea43a4a73928423f0372219052c5c6f87207f6c4754db14b91d6ed30`
+- Docker image (OCI): `floci/floci-oci:latest`
 - LocalStack Swarm smoke test: `scripts/tests/smoke-test-awssm.sh`

--- a/scripts/tests/README-floci.md
+++ b/scripts/tests/README-floci.md
@@ -30,10 +30,35 @@ bash scripts/tests/floci-kms-roundtrip.sh
 
 ## OCI
 
-The `oci-floci-tests` workflow (`.github/workflows/oci-floci-tests.yml`) uses [floci-oci](https://floci.io/floci-oci/) on port 4599. The smoke test (`scripts/tests/smoke-test-oci.sh`):
+The `oci-floci-tests` workflow (`.github/workflows/oci-floci-tests.yml`) uses [floci-oci](https://floci.io/floci-oci/) on port 4599. Vault, KMS, and Secrets share one host; see [Vault, KMS and Secrets](https://floci.io/floci-oci/services/kms-vault/).
 
-1. starts `floci/floci-oci` unless `http://localhost:4599/_floci-oci/health` already succeeds
-2. creates a vault, AES key, and secret (JSON `password` field)
+### KMS Vault roundtrip (no plugin)
+
+`scripts/tests/floci-oci-roundtrip.sh` is the OCI counterpart of `floci-kms-roundtrip.sh`:
+
+1. creates a DEFAULT vault and an AES-256 SOFTWARE key
+2. encrypts a test password with KMS (`POST /20180608/encrypt`)
+3. stores the ciphertext as a JSON `password` field in a vault secret
+4. fetches the bundle by name (`POST .../secretbundles/actions/getByName`) and by OCID
+5. decrypts without a `keyVersionId` (the ciphertext envelope carries it)
+6. rotates the secret and checks `CURRENT` vs `PREVIOUS` stages
+7. creates a new key version and confirms the previous ciphertext still decrypts
+
+Prerequisites: Docker, `curl`, and `jq`.
+
+```bash
+docker compose -f scripts/tests/floci-oci-compose.yml up -d
+bash scripts/tests/floci-oci-roundtrip.sh
+```
+
+Health: `curl http://localhost:4599/_floci-oci/health`
+
+### Swarm smoke
+
+`scripts/tests/smoke-test-oci.sh`:
+
+1. starts `floci/floci-oci` unless health already succeeds
+2. creates a vault, AES key, and secret
 3. fetches the secret bundle by name over REST
 4. builds the plugin with `OCI_ENDPOINT=http://localhost:4599` and a throwaway API key
 5. deploys a Swarm stack and verifies the mounted secret, including after rotation
@@ -41,9 +66,6 @@ The `oci-floci-tests` workflow (`.github/workflows/oci-floci-tests.yml`) uses [f
 ```bash
 bash scripts/tests/smoke-test-oci.sh
 ```
-
-Health: `curl http://localhost:4599/_floci-oci/health`  
-Vault/KMS/Secrets API notes: https://floci.io/floci-oci/services/kms-vault/
 
 ## References
 

--- a/scripts/tests/floci-oci-compose.yml
+++ b/scripts/tests/floci-oci-compose.yml
@@ -1,0 +1,5 @@
+services:
+  floci-oci:
+    image: floci/floci-oci:latest
+    ports:
+      - "4599:4599"

--- a/scripts/tests/floci-oci-roundtrip.sh
+++ b/scripts/tests/floci-oci-roundtrip.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# floci-oci-roundtrip.sh
+# Verifies OCI Vault + KMS + Secrets against a running floci-oci emulator
+# (https://floci.io/floci-oci/services/kms-vault/). Mirrors floci-kms-roundtrip.sh:
+# create vault and AES key, encrypt a value, store it as a JSON field in a vault
+# secret, fetch the bundle, decrypt without a keyVersionId (ciphertext envelope
+# carries it), rotate the secret, and confirm old ciphertext still decrypts after
+# a key-version rotation.
+
+set -euo pipefail
+
+OCI_ENDPOINT="${OCI_ENDPOINT:-http://localhost:4599}"
+OCI_TENANCY_OCID="${OCI_TENANCY_OCID:-ocid1.tenancy.oc1..flocilocaltenancy0000000000000000000000000000000000000000}"
+RUN_ID="${GITHUB_RUN_ID:-local-$(date +%s)}"
+VAULT_NAME="floci-ci-vault-${RUN_ID}"
+KEY_NAME="floci-ci-key-${RUN_ID}"
+SECRET_NAME="floci-ci-secret-${RUN_ID}"
+PLAINTEXT="oci-kms-pass-v1"
+PLAINTEXT_ROTATED="oci-kms-pass-v2"
+
+oci_api() {
+    curl -sf -H "Content-Type: application/json" "$@"
+}
+
+wait_for_state() {
+    local url="$1" expected="$2" elapsed=0
+    until [[ "$(oci_api "${url}" | jq -r '.lifecycleState // empty')" == "${expected}" ]]; do
+        sleep 2
+        elapsed=$((elapsed + 2))
+        if [[ "${elapsed}" -ge 60 ]]; then
+            echo "::error::${url} did not reach ${expected} within 60s" >&2
+            exit 1
+        fi
+    done
+}
+
+b64() {
+    if [[ $# -gt 0 ]]; then
+        printf '%s' "$1" | base64 -w0 2>/dev/null || printf '%s' "$1" | base64 | tr -d '\n'
+    else
+        base64 -w0 2>/dev/null || base64 | tr -d '\n'
+    fi
+}
+
+encrypt() {
+    jq -nc --arg keyId "${KEY_OCID}" --arg plaintext "$(b64 "$1")" \
+        '{keyId:$keyId,plaintext:$plaintext,encryptionAlgorithm:"AES_256_GCM"}' \
+        | oci_api -X POST "${OCI_ENDPOINT}/20180608/encrypt" -d @- \
+        | jq -r '.ciphertext'
+}
+
+decrypt() {
+    local ciphertext="$1"
+    local plaintext_b64
+    plaintext_b64="$(jq -nc --arg keyId "${KEY_OCID}" --arg ciphertext "${ciphertext}" \
+        '{keyId:$keyId,ciphertext:$ciphertext}' \
+        | oci_api -X POST "${OCI_ENDPOINT}/20180608/decrypt" -d @- \
+        | jq -r '.plaintext')"
+    printf '%s' "${plaintext_b64}" | base64 -d
+}
+
+json_secret() {
+    jq -nc --arg password "$1" '{password:$password}' | b64
+}
+
+fetch_bundle_by_name() {
+    local stage="${1:-}"
+    local url="${OCI_ENDPOINT}/20190301/secretbundles/actions/getByName?secretName=${SECRET_NAME}&vaultId=${VAULT_OCID}"
+    if [[ -n "${stage}" ]]; then
+        url="${url}&stage=${stage}"
+    fi
+    oci_api -X POST "${url}" | jq -r '.secretBundleContent.content'
+}
+
+fetch_bundle_by_id() {
+    oci_api "${OCI_ENDPOINT}/20190301/secretbundles/${SECRET_OCID}" \
+        | jq -r '.secretBundleContent.content'
+}
+
+roundtrip() {
+    local label="$1" expected="$2" fetched_b64="$3"
+    local ciphertext decrypted
+    ciphertext="$(printf '%s' "${fetched_b64}" | base64 -d | jq -r '.password')"
+    decrypted="$(decrypt "${ciphertext}")"
+    if [[ "${decrypted}" != "${expected}" ]]; then
+        echo "::error::${label}: decrypted '${decrypted}', expected '${expected}'" >&2
+        return 1
+    fi
+    echo "${label}: OK"
+}
+
+echo "Creating KMS vault ${VAULT_NAME}..."
+VAULT_OCID="$(oci_api -X POST "${OCI_ENDPOINT}/20180608/vaults" \
+    -d "{\"compartmentId\":\"${OCI_TENANCY_OCID}\",\"displayName\":\"${VAULT_NAME}\",\"vaultType\":\"DEFAULT\"}" \
+    | jq -r '.id')"
+wait_for_state "${OCI_ENDPOINT}/20180608/vaults/${VAULT_OCID}" "ACTIVE"
+echo "Vault: ${VAULT_OCID}"
+
+echo "Creating AES key ${KEY_NAME}..."
+KEY_OCID="$(oci_api -X POST "${OCI_ENDPOINT}/20180608/keys" \
+    -d "{\"compartmentId\":\"${OCI_TENANCY_OCID}\",\"displayName\":\"${KEY_NAME}\",\"protectionMode\":\"SOFTWARE\",\"keyShape\":{\"algorithm\":\"AES\",\"length\":32}}" \
+    | jq -r '.id')"
+wait_for_state "${OCI_ENDPOINT}/20180608/keys/${KEY_OCID}" "ENABLED"
+echo "Key: ${KEY_OCID}"
+
+echo "Encrypting and storing secret ${SECRET_NAME}..."
+SECRET_OCID="$(oci_api -X POST "${OCI_ENDPOINT}/20180608/secrets" \
+    -d "{\"compartmentId\":\"${OCI_TENANCY_OCID}\",\"vaultId\":\"${VAULT_OCID}\",\"keyId\":\"${KEY_OCID}\",\"secretName\":\"${SECRET_NAME}\",\"secretContent\":{\"contentType\":\"BASE64\",\"content\":\"$(json_secret "$(encrypt "${PLAINTEXT}")")\"}}" \
+    | jq -r '.id')"
+echo "Secret: ${SECRET_OCID}"
+
+roundtrip "GetSecretBundleByName" "${PLAINTEXT}" "$(fetch_bundle_by_name)"
+roundtrip "GetSecretBundle by OCID" "${PLAINTEXT}" "$(fetch_bundle_by_id)"
+
+echo "Rotating secret value..."
+oci_api -X PUT "${OCI_ENDPOINT}/20180608/secrets/${SECRET_OCID}" \
+    -d "{\"secretContent\":{\"contentType\":\"BASE64\",\"content\":\"$(json_secret "$(encrypt "${PLAINTEXT_ROTATED}")")\"}}" >/dev/null
+
+roundtrip "rotated CURRENT" "${PLAINTEXT_ROTATED}" "$(fetch_bundle_by_name CURRENT)"
+roundtrip "rotated PREVIOUS" "${PLAINTEXT}" "$(fetch_bundle_by_name PREVIOUS)"
+
+echo "Rotating key version (old ciphertext must still decrypt)..."
+OLD_CIPHERTEXT="$(printf '%s' "$(fetch_bundle_by_name CURRENT)" | base64 -d | jq -r '.password')"
+oci_api -X POST "${OCI_ENDPOINT}/20180608/keys/${KEY_OCID}/keyVersions" -d '{}' >/dev/null
+DECRYPTED_AFTER_KEY_ROTATE="$(decrypt "${OLD_CIPHERTEXT}")"
+if [[ "${DECRYPTED_AFTER_KEY_ROTATE}" != "${PLAINTEXT_ROTATED}" ]]; then
+    echo "::error::post-key-rotation decrypt: '${DECRYPTED_AFTER_KEY_ROTATE}', expected '${PLAINTEXT_ROTATED}'" >&2
+    exit 1
+fi
+echo "key-version rotation: OK"
+
+echo "OCI KMS Vault + Secrets roundtrip PASSED"

--- a/scripts/tests/floci-oci-roundtrip.sh
+++ b/scripts/tests/floci-oci-roundtrip.sh
@@ -36,14 +36,16 @@ wait_for_state() {
 
 b64() {
     if [[ $# -gt 0 ]]; then
-        printf '%s' "$1" | base64 -w0 2>/dev/null || printf '%s' "$1" | base64 | tr -d '\n'
+        local value="$1"
+        printf '%s' "${value}" | base64 -w0 2>/dev/null || printf '%s' "${value}" | base64 | tr -d '\n'
     else
         base64 -w0 2>/dev/null || base64 | tr -d '\n'
     fi
 }
 
 encrypt() {
-    jq -nc --arg keyId "${KEY_OCID}" --arg plaintext "$(b64 "$1")" \
+    local plaintext="$1"
+    jq -nc --arg keyId "${KEY_OCID}" --arg plaintext "$(b64 "${plaintext}")" \
         '{keyId:$keyId,plaintext:$plaintext,encryptionAlgorithm:"AES_256_GCM"}' \
         | oci_api -X POST "${OCI_ENDPOINT}/20180608/encrypt" -d @- \
         | jq -r '.ciphertext'
@@ -60,7 +62,8 @@ decrypt() {
 }
 
 json_secret() {
-    jq -nc --arg password "$1" '{password:$password}' | b64
+    local password="$1"
+    jq -nc --arg password "${password}" '{password:$password}' | b64
 }
 
 fetch_bundle_by_name() {

--- a/scripts/tests/smoke-oci-compose.yml
+++ b/scripts/tests/smoke-oci-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  app:
+    image: busybox:latest
+    command: >
+      sh -c "
+        while true; do
+          echo 'Current secret:'
+          cat /run/secrets/smoke_secret
+          sleep 2
+        done
+      "
+    secrets:
+      - smoke_secret
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+
+secrets:
+  smoke_secret:
+    driver: swarm-external-secrets:latest
+    labels:
+      oci_secret_name: "${OCI_SMOKE_SECRET_NAME:-smoke-test-secret}"
+      oci_field: "password"
+
+networks:
+  default:
+    driver: overlay

--- a/scripts/tests/smoke-test-oci.sh
+++ b/scripts/tests/smoke-test-oci.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+set -ex
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="${GITHUB_WORKSPACE:-$(realpath -- "${SCRIPT_DIR}/../..")}"
+# shellcheck source=smoke-test-helper.sh
+source "${SCRIPT_DIR}/smoke-test-helper.sh"
+
+# floci-oci is a lightweight open-source OCI emulator (https://floci.io/floci-oci/).
+# Vault, KMS, and Secrets share port 4599. Signatures are parsed for tenancy
+# context but never verified, so a throwaway RSA key is enough for the plugin.
+FLOCI_CONTAINER="smoke-floci-oci"
+FLOCI_IMAGE="floci/floci-oci:latest"
+OCI_ENDPOINT="${OCI_ENDPOINT:-http://localhost:4599}"
+OCI_REGION="${OCI_REGION:-us-ashburn-1}"
+OCI_TENANCY_OCID="${OCI_TENANCY_OCID:-ocid1.tenancy.oc1..flocilocaltenancy0000000000000000000000000000000000000000}"
+OCI_USER_OCID="${OCI_USER_OCID:-ocid1.user.oc1..flocilocaluser0000000000000000000000000000000000000000000000}"
+OCI_FINGERPRINT="${OCI_FINGERPRINT:-aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99}"
+OCI_AUTH_METHOD="${OCI_AUTH_METHOD:-api_key}"
+RUN_ID="${GITHUB_RUN_ID:-local-$(date +%s)}"
+STACK_NAME="smoke-oci"
+SECRET_NAME="smoke_secret"
+SECRET_PATH="smoke-test-secret-${RUN_ID}"
+SECRET_FIELD="password"
+SECRET_VALUE="oci-smoke-pass-v1"
+SECRET_VALUE_ROTATED="oci-smoke-pass-v2"
+VAULT_NAME="smoke-vault-${RUN_ID}"
+KEY_NAME="smoke-key-${RUN_ID}"
+COMPOSE_FILE="${SCRIPT_DIR}/smoke-oci-compose.yml"
+KEY_FILE="$(mktemp /tmp/floci-oci-key.XXXXXX.pem)"
+
+export OCI_SMOKE_SECRET_NAME="${SECRET_PATH}"
+
+oci_api() {
+    curl -sf \
+        -H "Content-Type: application/json" \
+        "$@"
+}
+
+json_payload() {
+    local value="$1"
+    printf '{"%s":"%s"}' "${SECRET_FIELD}" "${value}" | base64 -w0 2>/dev/null \
+        || printf '{"%s":"%s"}' "${SECRET_FIELD}" "${value}" | base64 | tr -d '\n'
+}
+
+wait_for_field() {
+    local url="$1"
+    local expected="$2"
+    local elapsed=0
+    until [[ "$(oci_api "${url}" | jq -r '.lifecycleState // empty')" == "${expected}" ]]; do
+        sleep 2
+        elapsed=$((elapsed + 2))
+        [[ "${elapsed}" -lt 60 ]] || die "Resource at ${url} did not reach ${expected} within 60s."
+    done
+}
+
+cleanup() {
+    echo -e "${RED}Running OCI Vault smoke test cleanup...${DEF}"
+    remove_stack "${STACK_NAME}"
+    docker secret rm "${SECRET_NAME}" 2>/dev/null || true
+    if [[ -n "${FLOCI_CONTAINER}" ]]; then
+        echo -e "${RED}floci-oci logs:${DEF}"
+        docker logs "${FLOCI_CONTAINER}" 2>/dev/null || true
+        docker stop "${FLOCI_CONTAINER}" 2>/dev/null || true
+        docker rm   "${FLOCI_CONTAINER}" 2>/dev/null || true
+    fi
+    rm -f "${KEY_FILE}"
+    remove_plugin
+}
+trap cleanup EXIT
+
+command -v curl >/dev/null 2>&1 || die "curl is required to run the OCI Vault smoke test."
+command -v jq >/dev/null 2>&1 || die "jq is required to run the OCI Vault smoke test."
+command -v openssl >/dev/null 2>&1 || die "openssl is required to generate a throwaway OCI API key."
+
+if curl -sf "${OCI_ENDPOINT}/_floci-oci/health" >/dev/null 2>&1; then
+    info "OCI emulator already running on 4599, skipping container start."
+    FLOCI_CONTAINER=""
+else
+    info "Starting floci-oci emulator container..."
+    docker run -d \
+        --name "${FLOCI_CONTAINER}" \
+        -p 4599:4599 \
+        "${FLOCI_IMAGE}"
+fi
+
+info "Waiting for floci-oci to be ready..."
+elapsed=0
+until curl -sf "${OCI_ENDPOINT}/_floci-oci/health" >/dev/null 2>&1; do
+    sleep 2
+    elapsed=$((elapsed + 2))
+    [[ "${elapsed}" -lt 60 ]] || die "floci-oci did not become ready within 60s."
+done
+success "floci-oci is ready."
+
+info "Creating vault ${VAULT_NAME}..."
+VAULT_OCID="$(oci_api -X POST "${OCI_ENDPOINT}/20180608/vaults" \
+    -d "{\"compartmentId\":\"${OCI_TENANCY_OCID}\",\"displayName\":\"${VAULT_NAME}\",\"vaultType\":\"DEFAULT\"}" \
+    | jq -r '.id')"
+[[ -n "${VAULT_OCID}" && "${VAULT_OCID}" != "null" ]] || die "Failed to create vault."
+wait_for_field "${OCI_ENDPOINT}/20180608/vaults/${VAULT_OCID}" "ACTIVE"
+success "Vault created: ${VAULT_OCID}"
+
+info "Creating AES master key ${KEY_NAME}..."
+KEY_OCID="$(oci_api -X POST "${OCI_ENDPOINT}/20180608/keys" \
+    -d "{\"compartmentId\":\"${OCI_TENANCY_OCID}\",\"displayName\":\"${KEY_NAME}\",\"protectionMode\":\"SOFTWARE\",\"keyShape\":{\"algorithm\":\"AES\",\"length\":32}}" \
+    | jq -r '.id')"
+[[ -n "${KEY_OCID}" && "${KEY_OCID}" != "null" ]] || die "Failed to create key."
+wait_for_field "${OCI_ENDPOINT}/20180608/keys/${KEY_OCID}" "ENABLED"
+success "Key created: ${KEY_OCID}"
+
+info "Creating secret ${SECRET_PATH}..."
+SECRET_OCID="$(oci_api -X POST "${OCI_ENDPOINT}/20180608/secrets" \
+    -d "{\"compartmentId\":\"${OCI_TENANCY_OCID}\",\"vaultId\":\"${VAULT_OCID}\",\"keyId\":\"${KEY_OCID}\",\"secretName\":\"${SECRET_PATH}\",\"secretContent\":{\"contentType\":\"BASE64\",\"content\":\"$(json_payload "${SECRET_VALUE}")\"}}" \
+    | jq -r '.id')"
+[[ -n "${SECRET_OCID}" && "${SECRET_OCID}" != "null" ]] || die "Failed to create secret."
+success "Secret written: ${SECRET_PATH}"
+
+info "Verifying secret bundle by name (no plugin)..."
+BUNDLE_B64="$(oci_api -X POST \
+    "${OCI_ENDPOINT}/20190301/secretbundles/actions/getByName?secretName=${SECRET_PATH}&vaultId=${VAULT_OCID}" \
+    | jq -r '.secretBundleContent.content')"
+ACTUAL_FIELD="$(printf '%s' "${BUNDLE_B64}" | base64 -d | jq -r --arg f "${SECRET_FIELD}" '.[$f]')"
+[[ "${ACTUAL_FIELD}" == "${SECRET_VALUE}" ]] || die "Bundle roundtrip expected ${SECRET_VALUE}, got ${ACTUAL_FIELD}"
+success "Secret bundle roundtrip OK."
+
+info "Generating throwaway OCI API key..."
+openssl genrsa -out "${KEY_FILE}" 2048 >/dev/null 2>&1
+OCI_KEY="$(base64 -w0 "${KEY_FILE}" 2>/dev/null || base64 "${KEY_FILE}" | tr -d '\n')"
+
+info "Building plugin and setting OCI Vault config..."
+build_plugin
+docker plugin disable "${PLUGIN_NAME}" --force 2>/dev/null || true
+docker plugin set "${PLUGIN_NAME}" \
+    SECRETS_PROVIDER="oci" \
+    OCI_AUTH_METHOD="${OCI_AUTH_METHOD}" \
+    OCI_REGION="${OCI_REGION}" \
+    OCI_TENANCY_OCID="${OCI_TENANCY_OCID}" \
+    OCI_USER_OCID="${OCI_USER_OCID}" \
+    OCI_FINGERPRINT="${OCI_FINGERPRINT}" \
+    OCI_PRIVATE_KEY="${OCI_KEY}" \
+    OCI_VAULT_OCID="${VAULT_OCID}" \
+    OCI_ENDPOINT="${OCI_ENDPOINT}" \
+    ENABLE_ROTATION="true" \
+    ROTATION_INTERVAL="10s" \
+    ENABLE_MONITORING="false"
+
+success "Plugin configured with OCI Vault settings."
+
+info "Enabling plugin..."
+enable_plugin
+
+info "Deploying swarm stack..."
+deploy_stack "${COMPOSE_FILE}" "${STACK_NAME}" 60
+
+info "Logging service output..."
+sleep 10
+log_stack "${STACK_NAME}" "app"
+assert_no_sensitive_rotation_metadata_logs
+
+info "Verifying secret value matches expected password..."
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE}" 60
+
+info "Rotating secret in OCI Vault..."
+oci_api -X PUT "${OCI_ENDPOINT}/20180608/secrets/${SECRET_OCID}" \
+    -d "{\"secretContent\":{\"contentType\":\"BASE64\",\"content\":\"$(json_payload "${SECRET_VALUE_ROTATED}")\"}}" >/dev/null
+success "Secret rotated to: ${SECRET_VALUE_ROTATED}"
+
+info "Waiting for plugin rotation interval..."
+sleep 30
+assert_no_sensitive_rotation_metadata_logs
+
+info "Logging service output after rotation..."
+log_stack "${STACK_NAME}" "app"
+
+info "Verifying rotated secret value..."
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE_ROTATED}" 180
+
+success "OCI Vault smoke test PASSED"


### PR DESCRIPTION
## Summary
- Adds an `oci-floci-tests` workflow that runs against [floci-oci](https://floci.io/floci-oci/) on port 4599 (vault + KMS + secret bundles).
- Smoke script creates a vault/key/secret, checks `GetSecretBundleByName`, then builds the plugin with `OCI_ENDPOINT` and verifies Swarm mount + rotation.
- Stacked on the OCI provider work (`feat/oci-provider`). **Depends on #146.**

```mermaid
flowchart BT
  main["origin/main"]
  p146["feat/oci-provider — #146 foundation"]
  tests["feat/oci-floci-tests — this PR"]
  main --> p146 --> tests
```

## Test plan
- [ ] `oci-floci-tests` workflow is green on this PR
- [ ] Smoke script starts floci-oci, writes a JSON secret, and the Swarm service sees `oci-smoke-pass-v1`
- [ ] After `PUT /20180608/secrets/{id}`, the service sees `oci-smoke-pass-v2`
- [ ] Lefthook / other provider smoke jobs stay green (no provider-only changes in this PR)


Made with [Cursor](https://cursor.com)