### PR TITLE
chore: add makim targets to preview and cut GitHub releases

### DIFF
--- a/.makim.yaml
+++ b/.makim.yaml
@@ -49,6 +49,16 @@ groups:
       smoke-test-openbao:
         help: Run OpenBao smoke test to validate plugin end-to-end
         run: bash ./scripts/tests/smoke-test-openbao.sh
+  release:
+    tasks:
+      dry-run:
+        help: Preview the next semantic version from conventional commits on origin/main
+        run: ./scripts/cut-release.sh --dry-run
+
+      cut:
+        help: Create a GitHub release from conventional commits on origin/main (no CI)
+        run: ./scripts/cut-release.sh
+
   ci:
     # Aggregate tasks useful for CI pipelines
     tasks:

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Preview or create a GitHub release from conventional commits on origin/main.
+# Version bump uses semantic-release commit-analyzer (Angular preset):
+#   feat: → minor, fix:/perf: → patch, BREAKING CHANGE / feat!: → major
+#   ci:/chore:/docs:/test:/refactor: → no release
+# This does not run in CI. Creating a GitHub Release triggers Publish Docker Plugin.
+
+set -euo pipefail
+
+cd -- "$(dirname -- "$0")/.." || exit 1
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+elif [[ -n "${1:-}" ]]; then
+  echo "Usage: $0 [--dry-run]" >&2
+  exit 2
+fi
+
+PREVIEW_BRANCH="makim-release-preview"
+WORKTREE=""
+
+cleanup() {
+  if [[ -n "${WORKTREE}" && -d "${WORKTREE}" ]]; then
+    git worktree remove --force "${WORKTREE}" >/dev/null 2>&1 || true
+  fi
+  git branch -D "${PREVIEW_BRANCH}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+semantic_release() {
+  if command -v bunx >/dev/null 2>&1; then
+    bunx semantic-release "$@"
+  elif command -v npx >/dev/null 2>&1; then
+    npx --yes semantic-release "$@"
+  else
+    echo "bunx or npx is required to run semantic-release" >&2
+    exit 1
+  fi
+}
+
+if [[ -z "${GITHUB_TOKEN:-${GH_TOKEN:-}}" ]] && command -v gh >/dev/null 2>&1; then
+  token="$(gh auth token 2>/dev/null || true)"
+  if [[ -n "${token}" ]]; then
+    export GITHUB_TOKEN="${token}"
+  fi
+fi
+
+git fetch origin main --tags
+
+WORKTREE="$(mktemp -d)"
+git worktree add -B "${PREVIEW_BRANCH}" "${WORKTREE}" origin/main >/dev/null
+cd "${WORKTREE}"
+
+echo "Analyzing origin/main at $(git rev-parse --short HEAD) (latest tag: $(git describe --tags --abbrev=0))"
+
+log="$(
+  semantic_release \
+    --dry-run \
+    --no-ci \
+    --branches "${PREVIEW_BRANCH}" \
+    --plugins @semantic-release/commit-analyzer \
+    --verify-conditions "" \
+    2>&1 | tee /dev/stderr
+)" || {
+  echo "semantic-release failed. Ensure bunx/npx can run, git can fetch origin, and you have push access to the repo." >&2
+  exit 1
+}
+
+if grep -q "There are no relevant changes, so no new version is released" <<<"${log}"; then
+  echo "No release-worthy commits on origin/main since $(git describe --tags --abbrev=0)."
+  exit 0
+fi
+
+VERSION="$(sed -nE 's/.*The next release version is ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' <<<"${log}" | tail -1)"
+if [[ -z "${VERSION}" ]]; then
+  echo "Could not parse the next version from semantic-release output." >&2
+  exit 1
+fi
+
+TAG="v${VERSION}"
+SHA="$(git rev-parse origin/main)"
+
+if ${DRY_RUN}; then
+  echo "Dry-run: would create GitHub release ${TAG} at ${SHA}"
+  echo "Cut with: makim release.cut"
+  exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required to create a GitHub release" >&2
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "Tag ${TAG} already exists" >&2
+  exit 1
+fi
+
+echo "Creating GitHub release ${TAG} at ${SHA}"
+gh release create "${TAG}" \
+  --title "${TAG}" \
+  --target "${SHA}" \
+  --generate-notes
+
+echo "Created ${TAG}. Publish Docker Plugin runs on the published release."


### PR DESCRIPTION
## Summary
- Adds `makim release.dry-run` and `makim release.cut` so releases are cut locally from conventional commits on `origin/main` (no CI).
- Dry-run uses `semantic-release` commit-analyzer (`feat` → minor, `fix` → patch, breaking → major). `release.cut` creates the GitHub Release that triggers plugin publishing from #193.

## Test plan
- [ ] From any branch: `makim release.dry-run` (expects no next version while `origin/main` is still `v1.2.0`).
- [ ] After a `feat:` or `fix:` lands on `main`, dry-run prints `v1.3.0` or `v1.2.1`.
- [ ] Merge #193 first, then this PR. `makim release.cut` should open a GitHub Release and start **Publish Docker Plugin**.

Stacked on https://github.com/sugar-org/swarm-external-secrets/pull/193


Made with [Cursor](https://cursor.com)