### PR TITLE
ci: add Vault and OpenBao JWT renewal smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -60,3 +60,22 @@ jobs:
       # preinstalled on ubuntu-latest runners.
       - name: Run smoke test for awssm
         run: bash scripts/tests/smoke-test-awssm.sh
+
+  smoke-test-jwt-renewal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        provider: [vault-jwt, openbao-jwt]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Init Docker Swarm
+        run: docker swarm init
+
+      - name: Run JWT renewal smoke test for ${{ matrix.provider }}
+        run: bash scripts/tests/smoke-test-${{ matrix.provider }}.sh

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -65,14 +65,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         provider: [vault-jwt, openbao-jwt]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
       - name: Init Docker Swarm
         run: docker swarm init

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -49,6 +49,20 @@ EOF
     rm -f "${tmp}"
 }
 
+# Pass a JWT into `docker plugin set` with xtrace off so `set -x` does not
+# print the token in CI logs.
+configure_plugin_jwt() {
+    local jwt_file="$1"
+    local jwt_env="$2"
+    shift 2
+    local jwt status=0
+    set +x
+    jwt="$(tr -d '\n' < "${jwt_file}")"
+    docker plugin set "${PLUGIN_NAME}" "$@" "${jwt_env}=${jwt}" || status=$?
+    set -x
+    return "${status}"
+}
+
 assert_no_sensitive_rotation_metadata_logs() {
     # Ensure trace-only rotation metadata isn't emitted at default log levels.
     # We look for the exact strings used by the driver.

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -29,13 +29,13 @@ docker_daemon_logs() {
     return 0
 }
 
-# Vault/OpenBao images land docker-cp files in /tmp as root, so appending inside
-# the container fails with "Permission denied". Assemble the policy on the host.
-copy_jwt_smoke_policy() {
+# Assemble the JWT smoke policy on the host and pipe it into `vault`/`bao
+# policy write -`. docker cp into /tmp as root leaves 0600 files the
+# non-root server user cannot read.
+write_jwt_smoke_policy() {
     local container="$1"
     local policy_file="$2"
-    local tmp
-    tmp="$(mktemp)"
+    shift 2
     {
         cat "${policy_file}"
         cat <<'EOF'
@@ -44,9 +44,7 @@ path "auth/token/renew-self" {
   capabilities = ["update"]
 }
 EOF
-    } > "${tmp}"
-    docker cp "${tmp}" "${container}:/tmp/admin.hcl"
-    rm -f "${tmp}"
+    } | docker exec -i "${container}" "$@"
 }
 
 # Pass a JWT into `docker plugin set` with xtrace off so `set -x` does not

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -45,6 +45,7 @@ path "auth/token/renew-self" {
 }
 EOF
     } | docker exec -i "${container}" "$@"
+    return $?
 }
 
 # Pass a JWT into `docker plugin set` with xtrace off so `set -x` does not

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -36,29 +36,39 @@ write_jwt_smoke_policy() {
     local container="$1"
     local policy_file="$2"
     shift 2
-    {
-        cat "${policy_file}"
-        cat <<'EOF'
+    local tmp status=0
+    tmp="$(mktemp)"
+    if [[ ! -r "${policy_file}" ]] || ! cat "${policy_file}" > "${tmp}"; then
+        rm -f "${tmp}"
+        return 1
+    fi
+    cat <<'EOF' >> "${tmp}"
 
 path "auth/token/renew-self" {
   capabilities = ["update"]
 }
 EOF
-    } | docker exec -i "${container}" "$@"
-    return $?
+    docker exec -i "${container}" "$@" < "${tmp}" || status=$?
+    rm -f "${tmp}"
+    return "${status}"
 }
 
 # Pass a JWT into `docker plugin set` with xtrace off so `set -x` does not
-# print the token in CI logs.
+# print the token in CI logs. Restore xtrace only if the caller had it on.
 configure_plugin_jwt() {
     local jwt_file="$1"
     local jwt_env="$2"
     shift 2
-    local jwt status=0
+    local jwt status=0 xtrace_was_on=0
+    case "$-" in
+        *x*) xtrace_was_on=1 ;;
+    esac
     set +x
     jwt="$(tr -d '\n' < "${jwt_file}")"
     docker plugin set "${PLUGIN_NAME}" "$@" "${jwt_env}=${jwt}" || status=$?
-    set -x
+    if [[ "${xtrace_was_on}" -eq 1 ]]; then
+        set -x
+    fi
     return "${status}"
 }
 

--- a/scripts/tests/smoke-test-helper.sh
+++ b/scripts/tests/smoke-test-helper.sh
@@ -29,6 +29,26 @@ docker_daemon_logs() {
     return 0
 }
 
+# Vault/OpenBao images land docker-cp files in /tmp as root, so appending inside
+# the container fails with "Permission denied". Assemble the policy on the host.
+copy_jwt_smoke_policy() {
+    local container="$1"
+    local policy_file="$2"
+    local tmp
+    tmp="$(mktemp)"
+    {
+        cat "${policy_file}"
+        cat <<'EOF'
+
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+EOF
+    } > "${tmp}"
+    docker cp "${tmp}" "${container}:/tmp/admin.hcl"
+    rm -f "${tmp}"
+}
+
 assert_no_sensitive_rotation_metadata_logs() {
     # Ensure trace-only rotation metadata isn't emitted at default log levels.
     # We look for the exact strings used by the driver.

--- a/scripts/tests/smoke-test-openbao-jwt.sh
+++ b/scripts/tests/smoke-test-openbao-jwt.sh
@@ -136,10 +136,9 @@ done
 success "OpenBao is ready."
 
 info "Applying policy to OpenBao..."
-copy_jwt_smoke_policy "${OPENBAO_CONTAINER}" "${POLICY_FILE}"
-docker exec "${OPENBAO_CONTAINER}" \
+write_jwt_smoke_policy "${OPENBAO_CONTAINER}" "${POLICY_FILE}" \
     env BAO_ADDR="${OPENBAO_ADDR}" BAO_TOKEN="${OPENBAO_ROOT_TOKEN}" \
-    bao policy write smoke-policy /tmp/admin.hcl
+    bao policy write smoke-policy -
 success "Policy applied."
 
 info "Writing test secret to OpenBao..."
@@ -152,6 +151,7 @@ success "Secret written."
 
 info "Generating local JWT signing keys and signed JWT..."
 generate_local_jwt
+chmod 0644 "${JWT_WORKDIR}/jwt-public.pem"
 docker cp "${JWT_WORKDIR}/jwt-public.pem" "${OPENBAO_CONTAINER}:/tmp/jwt-public.pem"
 
 info "Configuring OpenBao JWT auth..."

--- a/scripts/tests/smoke-test-openbao-jwt.sh
+++ b/scripts/tests/smoke-test-openbao-jwt.sh
@@ -136,13 +136,7 @@ done
 success "OpenBao is ready."
 
 info "Applying policy to OpenBao..."
-docker cp "${POLICY_FILE}" "${OPENBAO_CONTAINER}:/tmp/admin.hcl"
-docker exec "${OPENBAO_CONTAINER}" sh -lc 'cat >>/tmp/admin.hcl <<EOF
-
-path "auth/token/renew-self" {
-  capabilities = ["update"]
-}
-EOF'
+copy_jwt_smoke_policy "${OPENBAO_CONTAINER}" "${POLICY_FILE}"
 docker exec "${OPENBAO_CONTAINER}" \
     env BAO_ADDR="${OPENBAO_ADDR}" BAO_TOKEN="${OPENBAO_ROOT_TOKEN}" \
     bao policy write smoke-policy /tmp/admin.hcl

--- a/scripts/tests/smoke-test-openbao-jwt.sh
+++ b/scripts/tests/smoke-test-openbao-jwt.sh
@@ -175,17 +175,14 @@ docker exec "${OPENBAO_CONTAINER}" \
         max_ttl="${JWT_TOKEN_MAX_TTL}"
 success "OpenBao JWT auth configured."
 
-WORKLOAD_JWT="$(tr -d '\n' < "${JWT_WORKDIR}/workload.jwt")"
-
 info "Building plugin and configuring JWT auth..."
 build_plugin
 
-docker plugin set "${PLUGIN_NAME}" \
+configure_plugin_jwt "${JWT_WORKDIR}/workload.jwt" OPENBAO_JWT \
     SECRETS_PROVIDER="openbao" \
     OPENBAO_ADDR="${OPENBAO_ADDR}" \
     OPENBAO_AUTH_METHOD="jwt" \
     OPENBAO_JWT_ROLE="${JWT_ROLE}" \
-    OPENBAO_JWT="${WORKLOAD_JWT}" \
     OPENBAO_JWT_AUTH_PATH="jwt" \
     OPENBAO_MOUNT_PATH="secret" \
     ENABLE_ROTATION="false" \

--- a/scripts/tests/smoke-test-openbao-jwt.sh
+++ b/scripts/tests/smoke-test-openbao-jwt.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+set -ex
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(realpath -- "${SCRIPT_DIR}/../..")"
+
+# shellcheck source=smoke-test-helper.sh
+source "${SCRIPT_DIR}/smoke-test-helper.sh"
+
+OPENBAO_CONTAINER="smoke-openbao-jwt"
+OPENBAO_ROOT_TOKEN="smoke-root-token"
+OPENBAO_ADDR="http://127.0.0.1:8200"
+STACK_NAME="smoke-openbao-jwt"
+SECRET_NAME="smoke_secret"
+SECRET_PATH="database/mysql"
+SECRET_FIELD="password"
+SECRET_VALUE="openbao-jwt-smoke-pass-v1"
+COMPOSE_FILE="${SCRIPT_DIR}/smoke-openbao-compose.yml"
+POLICY_FILE="${REPO_ROOT}/vault_conf/admin.hcl"
+JWT_WORKDIR="$(mktemp -d)"
+JWT_ROLE="swarm-external-secrets"
+JWT_TOKEN_TTL="10s"
+JWT_TOKEN_MAX_TTL="25s"
+RENEWAL_WAIT_SECONDS=45
+LOG_EXPORT_DIR="${REPO_ROOT}/.tmp/smoke-openbao-jwt"
+PLUGIN_LOG_PATH="/run/swarm-external-secrets/plugin.log"
+PLUGIN_LOG_EXPORT="${LOG_EXPORT_DIR}/plugin.log"
+DAEMON_LOG_EXPORT="${LOG_EXPORT_DIR}/docker-daemon.log"
+EXIT_CODE=0
+
+base64url() {
+    openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+generate_local_jwt() {
+    openssl genrsa -out "${JWT_WORKDIR}/jwt-private.pem" 2048 >/dev/null 2>&1
+    openssl rsa -in "${JWT_WORKDIR}/jwt-private.pem" -pubout -out "${JWT_WORKDIR}/jwt-public.pem" >/dev/null 2>&1
+
+    local header payload unsigned signature
+    header="$(printf '{"alg":"RS256","typ":"JWT"}' | base64url)"
+    payload="$(printf '{"iss":"swarm-external-secrets-local","sub":"swarm-external-secrets","aud":"vault"}' | base64url)"
+    unsigned="${header}.${payload}"
+    signature="$(printf '%s' "${unsigned}" | openssl dgst -sha256 -sign "${JWT_WORKDIR}/jwt-private.pem" -binary | base64url)"
+    printf '%s.%s\n' "${unsigned}" "${signature}" > "${JWT_WORKDIR}/workload.jwt"
+}
+
+prepare_plugin_log_path() {
+    mkdir -p "${LOG_EXPORT_DIR}"
+    : > "${PLUGIN_LOG_EXPORT}"
+
+    if [[ "$(uname -s)" = "Darwin" ]]; then
+        info "Preparing plugin log path inside Docker Desktop VM..."
+        docker run --rm --privileged --pid=host justincormack/nsenter1 \
+            sh -lc "mkdir -p /run/swarm-external-secrets && touch '${PLUGIN_LOG_PATH}' && chmod -R 777 /run/swarm-external-secrets"
+        return
+    fi
+
+    info "Preparing plugin log path on Linux host..."
+    if [[ "$(id -u)" -eq 0 ]]; then
+        mkdir -p /run/swarm-external-secrets
+        touch "${PLUGIN_LOG_PATH}"
+    else
+        sudo mkdir -p /run/swarm-external-secrets
+        sudo touch "${PLUGIN_LOG_PATH}"
+    fi
+}
+
+export_plugin_logs() {
+    mkdir -p "${LOG_EXPORT_DIR}"
+
+    if [[ "$(uname -s)" = "Darwin" ]]; then
+        docker run --rm --privileged --pid=host justincormack/nsenter1 \
+            sh -lc "cat '${PLUGIN_LOG_PATH}' 2>/dev/null" > "${PLUGIN_LOG_EXPORT}" || true
+    elif [[ -r "${PLUGIN_LOG_PATH}" ]]; then
+        cp "${PLUGIN_LOG_PATH}" "${PLUGIN_LOG_EXPORT}" || true
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo cp "${PLUGIN_LOG_PATH}" "${PLUGIN_LOG_EXPORT}" 2>/dev/null || true
+        sudo chown "$(id -u):$(id -g)" "${PLUGIN_LOG_EXPORT}" 2>/dev/null || true
+    fi
+
+    docker_daemon_logs > "${DAEMON_LOG_EXPORT}" || true
+    info "Exported plugin logs to: ${PLUGIN_LOG_EXPORT}"
+    info "Exported Docker daemon logs to: ${DAEMON_LOG_EXPORT}"
+}
+
+assert_log_contains_any() {
+    local description="$1"
+    shift
+
+    export_plugin_logs
+    local logs
+    logs="$(cat "${PLUGIN_LOG_EXPORT}" "${DAEMON_LOG_EXPORT}" 2>/dev/null || true)"
+
+    for expected in "$@"; do
+        if echo "${logs}" | grep -Fq "${expected}"; then
+            success "${description}: found '${expected}'"
+            return
+        fi
+    done
+
+    die "${description}: expected one of [$*]. See exported logs in ${LOG_EXPORT_DIR}"
+}
+
+cleanup() {
+    EXIT_CODE=$?
+    set +e
+    echo -e "${RED}Running OpenBao JWT smoke test cleanup...${DEF}"
+    export_plugin_logs
+    remove_stack "${STACK_NAME}"
+    docker secret rm "${SECRET_NAME}" 2>/dev/null || true
+    docker stop "${OPENBAO_CONTAINER}" 2>/dev/null || true
+    docker rm   "${OPENBAO_CONTAINER}" 2>/dev/null || true
+    rm -rf "${JWT_WORKDIR}"
+    remove_plugin
+    exit "${EXIT_CODE}"
+}
+trap cleanup EXIT
+
+prepare_plugin_log_path
+
+info "Starting OpenBao dev container..."
+docker run -d \
+    --name "${OPENBAO_CONTAINER}" \
+    -p 8200:8200 \
+    -e "BAO_DEV_ROOT_TOKEN_ID=${OPENBAO_ROOT_TOKEN}" \
+    quay.io/openbao/openbao:latest server -dev
+
+info "Waiting for OpenBao to be ready..."
+elapsed=0
+until docker exec "${OPENBAO_CONTAINER}" bao status -address="${OPENBAO_ADDR}" >/dev/null 2>&1; do
+    sleep 2
+    elapsed=$((elapsed + 2))
+    [[ "${elapsed}" -lt 30 ]] || die "OpenBao did not become ready within 30s."
+done
+success "OpenBao is ready."
+
+info "Applying policy to OpenBao..."
+docker cp "${POLICY_FILE}" "${OPENBAO_CONTAINER}:/tmp/admin.hcl"
+docker exec "${OPENBAO_CONTAINER}" sh -lc 'cat >>/tmp/admin.hcl <<EOF
+
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+EOF'
+docker exec "${OPENBAO_CONTAINER}" \
+    env BAO_ADDR="${OPENBAO_ADDR}" BAO_TOKEN="${OPENBAO_ROOT_TOKEN}" \
+    bao policy write smoke-policy /tmp/admin.hcl
+success "Policy applied."
+
+info "Writing test secret to OpenBao..."
+docker exec "${OPENBAO_CONTAINER}" \
+    env BAO_ADDR="${OPENBAO_ADDR}" BAO_TOKEN="${OPENBAO_ROOT_TOKEN}" \
+    bao kv put \
+    "secret/${SECRET_PATH}" \
+    "${SECRET_FIELD}=${SECRET_VALUE}"
+success "Secret written."
+
+info "Generating local JWT signing keys and signed JWT..."
+generate_local_jwt
+docker cp "${JWT_WORKDIR}/jwt-public.pem" "${OPENBAO_CONTAINER}:/tmp/jwt-public.pem"
+
+info "Configuring OpenBao JWT auth..."
+docker exec "${OPENBAO_CONTAINER}" \
+    env BAO_ADDR="${OPENBAO_ADDR}" BAO_TOKEN="${OPENBAO_ROOT_TOKEN}" \
+    bao auth enable jwt
+docker exec "${OPENBAO_CONTAINER}" \
+    env BAO_ADDR="${OPENBAO_ADDR}" BAO_TOKEN="${OPENBAO_ROOT_TOKEN}" \
+    bao write auth/jwt/config \
+        jwt_validation_pubkeys=@/tmp/jwt-public.pem \
+        bound_issuer="swarm-external-secrets-local"
+docker exec "${OPENBAO_CONTAINER}" \
+    env BAO_ADDR="${OPENBAO_ADDR}" BAO_TOKEN="${OPENBAO_ROOT_TOKEN}" \
+    bao write "auth/jwt/role/${JWT_ROLE}" \
+        role_type="jwt" \
+        user_claim="sub" \
+        bound_audiences="vault" \
+        bound_subject="swarm-external-secrets" \
+        policies="smoke-policy" \
+        ttl="${JWT_TOKEN_TTL}" \
+        max_ttl="${JWT_TOKEN_MAX_TTL}"
+success "OpenBao JWT auth configured."
+
+WORKLOAD_JWT="$(tr -d '\n' < "${JWT_WORKDIR}/workload.jwt")"
+
+info "Building plugin and configuring JWT auth..."
+build_plugin
+
+docker plugin set "${PLUGIN_NAME}" \
+    SECRETS_PROVIDER="openbao" \
+    OPENBAO_ADDR="${OPENBAO_ADDR}" \
+    OPENBAO_AUTH_METHOD="jwt" \
+    OPENBAO_JWT_ROLE="${JWT_ROLE}" \
+    OPENBAO_JWT="${WORKLOAD_JWT}" \
+    OPENBAO_JWT_AUTH_PATH="jwt" \
+    OPENBAO_MOUNT_PATH="secret" \
+    ENABLE_ROTATION="false" \
+    ENABLE_MONITORING="false" \
+    LOG_LEVEL="debug" \
+    PLUGIN_LOG_PATH="${PLUGIN_LOG_PATH}"
+success "Plugin configured with OpenBao JWT auth."
+
+info "Enabling plugin..."
+enable_plugin
+
+info "Deploying swarm stack..."
+deploy_stack "${COMPOSE_FILE}" "${STACK_NAME}" 60
+
+info "Verifying secret value matches expected password..."
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE}" 60
+
+info "Waiting ${RENEWAL_WAIT_SECONDS}s for JWT token renewal and max-TTL re-auth paths..."
+sleep "${RENEWAL_WAIT_SECONDS}"
+export_plugin_logs
+
+assert_log_contains_any \
+    "JWT renewal path" \
+    "Successfully renewed openbao token"
+
+assert_log_contains_any \
+    "JWT re-auth fallback path" \
+    "Renewing openbao token failed, attempting re-authentication" \
+    "Successfully re-authenticated with openbao"
+
+info "Re-deploying stack to prove reads still work after original token max TTL..."
+remove_stack "${STACK_NAME}"
+docker secret rm "${SECRET_NAME}" 2>/dev/null || true
+deploy_stack "${COMPOSE_FILE}" "${STACK_NAME}" 60
+verify_secret "${STACK_NAME}" "app" "${SECRET_NAME}" "${SECRET_VALUE}" 60
+
+success "OpenBao JWT smoke test PASSED"

--- a/scripts/tests/smoke-test-openbao-jwt.sh
+++ b/scripts/tests/smoke-test-openbao-jwt.sh
@@ -37,9 +37,12 @@ generate_local_jwt() {
     openssl genrsa -out "${JWT_WORKDIR}/jwt-private.pem" 2048 >/dev/null 2>&1
     openssl rsa -in "${JWT_WORKDIR}/jwt-private.pem" -pubout -out "${JWT_WORKDIR}/jwt-public.pem" >/dev/null 2>&1
 
-    local header payload unsigned signature
+    local header payload unsigned signature now exp
+    now="$(date +%s)"
+    exp="$((now + 3600))"
     header="$(printf '{"alg":"RS256","typ":"JWT"}' | base64url)"
-    payload="$(printf '{"iss":"swarm-external-secrets-local","sub":"swarm-external-secrets","aud":"vault"}' | base64url)"
+    # Vault/OpenBao JWT auth rejects tokens that omit iat, nbf, and exp.
+    payload="$(printf '{"iss":"swarm-external-secrets-local","sub":"swarm-external-secrets","aud":"vault","iat":%s,"nbf":%s,"exp":%s}' "${now}" "${now}" "${exp}" | base64url)"
     unsigned="${header}.${payload}"
     signature="$(printf '%s' "${unsigned}" | openssl dgst -sha256 -sign "${JWT_WORKDIR}/jwt-private.pem" -binary | base64url)"
     printf '%s.%s\n' "${unsigned}" "${signature}" > "${JWT_WORKDIR}/workload.jwt"

--- a/scripts/tests/smoke-test-vault-jwt.sh
+++ b/scripts/tests/smoke-test-vault-jwt.sh
@@ -136,13 +136,7 @@ done
 success "Vault is ready."
 
 info "Applying policy to Vault..."
-docker cp "${POLICY_FILE}" "${VAULT_CONTAINER}:/tmp/admin.hcl"
-docker exec "${VAULT_CONTAINER}" sh -lc 'cat >>/tmp/admin.hcl <<EOF
-
-path "auth/token/renew-self" {
-  capabilities = ["update"]
-}
-EOF'
+copy_jwt_smoke_policy "${VAULT_CONTAINER}" "${POLICY_FILE}"
 docker exec "${VAULT_CONTAINER}" \
     env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
     vault policy write smoke-policy /tmp/admin.hcl

--- a/scripts/tests/smoke-test-vault-jwt.sh
+++ b/scripts/tests/smoke-test-vault-jwt.sh
@@ -136,10 +136,9 @@ done
 success "Vault is ready."
 
 info "Applying policy to Vault..."
-copy_jwt_smoke_policy "${VAULT_CONTAINER}" "${POLICY_FILE}"
-docker exec "${VAULT_CONTAINER}" \
+write_jwt_smoke_policy "${VAULT_CONTAINER}" "${POLICY_FILE}" \
     env VAULT_ADDR="${VAULT_ADDR}" VAULT_TOKEN="${VAULT_ROOT_TOKEN}" \
-    vault policy write smoke-policy /tmp/admin.hcl
+    vault policy write smoke-policy -
 success "Policy applied."
 
 info "Writing test secret to Vault..."
@@ -152,6 +151,7 @@ success "Secret written."
 
 info "Generating local JWT signing keys and signed JWT..."
 generate_local_jwt
+chmod 0644 "${JWT_WORKDIR}/jwt-public.pem"
 docker cp "${JWT_WORKDIR}/jwt-public.pem" "${VAULT_CONTAINER}:/tmp/jwt-public.pem"
 
 info "Configuring Vault JWT auth..."

--- a/scripts/tests/smoke-test-vault-jwt.sh
+++ b/scripts/tests/smoke-test-vault-jwt.sh
@@ -175,17 +175,14 @@ docker exec "${VAULT_CONTAINER}" \
         max_ttl="${JWT_TOKEN_MAX_TTL}"
 success "Vault JWT auth configured."
 
-WORKLOAD_JWT="$(tr -d '\n' < "${JWT_WORKDIR}/workload.jwt")"
-
 info "Building plugin and configuring JWT auth..."
 build_plugin
 
-docker plugin set "${PLUGIN_NAME}" \
+configure_plugin_jwt "${JWT_WORKDIR}/workload.jwt" VAULT_JWT \
     SECRETS_PROVIDER="vault" \
     VAULT_ADDR="${VAULT_ADDR}" \
     VAULT_AUTH_METHOD="jwt" \
     VAULT_JWT_ROLE="${JWT_ROLE}" \
-    VAULT_JWT="${WORKLOAD_JWT}" \
     VAULT_JWT_AUTH_PATH="jwt" \
     VAULT_MOUNT_PATH="secret" \
     ENABLE_ROTATION="false" \

--- a/scripts/tests/smoke-test-vault-jwt.sh
+++ b/scripts/tests/smoke-test-vault-jwt.sh
@@ -37,9 +37,12 @@ generate_local_jwt() {
     openssl genrsa -out "${JWT_WORKDIR}/jwt-private.pem" 2048 >/dev/null 2>&1
     openssl rsa -in "${JWT_WORKDIR}/jwt-private.pem" -pubout -out "${JWT_WORKDIR}/jwt-public.pem" >/dev/null 2>&1
 
-    local header payload unsigned signature
+    local header payload unsigned signature now exp
+    now="$(date +%s)"
+    exp="$((now + 3600))"
     header="$(printf '{"alg":"RS256","typ":"JWT"}' | base64url)"
-    payload="$(printf '{"iss":"swarm-external-secrets-local","sub":"swarm-external-secrets","aud":"vault"}' | base64url)"
+    # Vault/OpenBao JWT auth rejects tokens that omit iat, nbf, and exp.
+    payload="$(printf '{"iss":"swarm-external-secrets-local","sub":"swarm-external-secrets","aud":"vault","iat":%s,"nbf":%s,"exp":%s}' "${now}" "${now}" "${exp}" | base64url)"
     unsigned="${header}.${payload}"
     signature="$(printf '%s' "${unsigned}" | openssl dgst -sha256 -sign "${JWT_WORKDIR}/jwt-private.pem" -binary | base64url)"
     printf '%s.%s\n' "${unsigned}" "${signature}" > "${JWT_WORKDIR}/workload.jwt"


### PR DESCRIPTION
## Summary
- Add a `smoke-test-jwt-renewal` matrix job (`vault-jwt`, `openbao-jwt`) to Smoke Tests so live JWT token renewal runs in CI.
- Add `scripts/tests/smoke-test-openbao-jwt.sh`, mirroring the existing Vault JWT smoke (10s TTL / 25s max TTL / 45s wait) with OpenBao compose, `OPENBAO_*` JWT env, and `openbao` log assertions.
- Stacked on #194 (`chore/makim-release-cut`); CI on this PR is the verification that both jobs work.

## Test plan
- [ ] Confirm Smoke Tests starts `smoke-test-jwt-renewal (vault-jwt)` and `smoke-test-jwt-renewal (openbao-jwt)`.
- [ ] Vault job asserts `Successfully renewed vault token` and re-auth (`Renewing vault token failed...` or `Successfully re-authenticated with vault`), then secret reads still work after redeploy.
- [ ] OpenBao job asserts `Successfully renewed openbao token` and the matching re-auth strings, then secret reads still work after redeploy.
- [ ] Existing token-auth smoke jobs (`vault`, `openbao`, custom-path, awssm) still pass.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated smoke testing for JWT renewal across Vault and OpenBao providers.
  * Added coverage for secret access, token renewal, JWT re-authentication, logging, and post-expiration redeployment.
  * Added automated setup and cleanup for the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->