### PR TITLE
docs: Vault and OpenBao JWT auth and token renewal

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -57,6 +57,31 @@ vault write auth/approle/role/my-role \
     token_policies="db-policy"
 ```
 
+## JWT authentication
+
+JWT login and client-token renewal (including max-TTL re-login) are documented in
+[Vault and OpenBao JWT](jwt.md).
+
+Enable JWT auth and a role, then configure the plugin with `VAULT_AUTH_METHOD=jwt`
+(or `OPENBAO_AUTH_METHOD=jwt`). Current Vault/OpenBao JWT auth requires the
+identity token to include at least one of `iat`, `nbf`, or `exp`.
+
+The issued client token policy should allow renew-self:
+
+```hcl
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+```
+
+Renewal and re-auth log lines (with `vault` or `openbao` as the provider name):
+
+```text
+Successfully renewed vault token
+Renewing vault token failed, attempting re-authentication
+Successfully re-authenticated with vault
+```
+
 ## Set and Get KV Secrets
 
 ```bash

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -74,7 +74,9 @@ path "auth/token/renew-self" {
 }
 ```
 
-Renewal and re-auth log lines (with `vault` or `openbao` as the provider name):
+Renewal and re-auth log lines (with `vault` or `openbao` as the provider name).
+The re-auth warning is visible at the default log level; the two success lines
+are debug-only (`LOG_LEVEL=debug` or `6`):
 
 ```text
 Successfully renewed vault token

--- a/docs/jwt.md
+++ b/docs/jwt.md
@@ -24,9 +24,10 @@ used. The file is read again on every re-login, so you can rotate the identity
 JWT on disk without reconfiguring the plugin. A JWT stored in `*_JWT` is fixed
 until the next `docker plugin set`.
 
-`*_JWT_FILE` is opened **inside the plugin**. The plugin bind-mounts host
-`/run/swarm-external-secrets`, so put the file there (or another mounted path)
-and point the env var at that in-plugin path.
+`*_JWT_FILE` is opened **inside the plugin**. The default plugin config
+bind-mounts host `/run/swarm-external-secrets` only, so the JWT file must live
+under that directory (same path on the host and in the plugin). Additional
+paths work only if you ship a custom plugin with extra mounts.
 
 ### Environment JWT
 
@@ -56,7 +57,7 @@ docker plugin set swarm-external-secrets:latest \
 
 ```bash
 sudo mkdir -p /run/swarm-external-secrets
-sudo install -m 0644 ./workload.jwt /run/swarm-external-secrets/workload.jwt
+sudo install -m 0600 ./workload.jwt /run/swarm-external-secrets/workload.jwt
 
 docker plugin set swarm-external-secrets:latest \
     SECRETS_PROVIDER="vault" \
@@ -72,8 +73,12 @@ Enable JWT auth and create a role whose policies can read your KV secrets.
 The issued token must also be allowed to renew itself:
 
 ```hcl
-path "secret/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
+path "secret/data/*" {
+  capabilities = ["read"]
+}
+
+path "secret/metadata/*" {
+  capabilities = ["list"]
 }
 
 path "auth/token/renew-self" {
@@ -112,13 +117,12 @@ When the issued token is renewable and has a positive TTL, a background worker:
 Retries after a failed renew use a 5s wait that doubles up to one minute.
 
 Look for these plugin log lines (`vault` or `openbao` depending on the
-provider):
+provider). The re-auth warning is emitted at warn level; the two success lines
+are **debug** (`LOG_LEVEL=debug` or `6`):
 
-- `Successfully renewed vault token`
-- `Renewing vault token failed, attempting re-authentication`
-- `Successfully re-authenticated with vault`
-
-Enable `LOG_LEVEL=debug` (or `6`) if you need the debug-level renewal lines.
+- `Successfully renewed vault token` (debug)
+- `Renewing vault token failed, attempting re-authentication` (warn)
+- `Successfully re-authenticated with vault` (debug)
 
 !!! warning "Static tokens do not auto-renew"
     `VAULT_AUTH_METHOD=token` (the default) never starts the renewal worker.

--- a/docs/jwt.md
+++ b/docs/jwt.md
@@ -1,0 +1,136 @@
+# Vault and OpenBao JWT authentication
+
+The plugin can log in to HashiCorp Vault and OpenBao with a signed JWT, then
+keep the **issued client token** alive. That client-token renewal is not the
+same as [secret rotation](rotation.md).
+
+OpenBao uses the same behavior with `OPENBAO_*` variables instead of `VAULT_*`.
+
+## Plugin configuration
+
+Set `VAULT_AUTH_METHOD=jwt` (or `OPENBAO_AUTH_METHOD=jwt`). You must also set a
+role name and provide a JWT from the environment **or** a file.
+
+| Variable | Description | Default |
+|---|---|---|
+| `VAULT_AUTH_METHOD` / `OPENBAO_AUTH_METHOD` | Set to `jwt` | `token` |
+| `VAULT_JWT_ROLE` / `OPENBAO_JWT_ROLE` | JWT/OIDC role name (required) | — |
+| `VAULT_JWT` / `OPENBAO_JWT` | Signed JWT string | — |
+| `VAULT_JWT_FILE` / `OPENBAO_JWT_FILE` | Path to a file containing the JWT | — |
+| `VAULT_JWT_AUTH_PATH` / `OPENBAO_JWT_AUTH_PATH` | Auth mount path | `jwt` |
+
+Either `*_JWT` or `*_JWT_FILE` is required. If both are set, the **file** is
+used. The file is read again on every re-login, so you can rotate the identity
+JWT on disk without reconfiguring the plugin. A JWT stored in `*_JWT` is fixed
+until the next `docker plugin set`.
+
+`*_JWT_FILE` is opened **inside the plugin**. The plugin bind-mounts host
+`/run/swarm-external-secrets`, so put the file there (or another mounted path)
+and point the env var at that in-plugin path.
+
+### Environment JWT
+
+```bash
+docker plugin set swarm-external-secrets:latest \
+    SECRETS_PROVIDER="vault" \
+    VAULT_ADDR="https://vault.example.com:8200" \
+    VAULT_AUTH_METHOD="jwt" \
+    VAULT_JWT_ROLE="swarm-external-secrets" \
+    VAULT_JWT="<signed-jwt>" \
+    VAULT_JWT_AUTH_PATH="jwt"
+```
+
+OpenBao:
+
+```bash
+docker plugin set swarm-external-secrets:latest \
+    SECRETS_PROVIDER="openbao" \
+    OPENBAO_ADDR="https://openbao.example.com:8200" \
+    OPENBAO_AUTH_METHOD="jwt" \
+    OPENBAO_JWT_ROLE="swarm-external-secrets" \
+    OPENBAO_JWT="<signed-jwt>" \
+    OPENBAO_JWT_AUTH_PATH="jwt"
+```
+
+### JWT file
+
+```bash
+sudo mkdir -p /run/swarm-external-secrets
+sudo install -m 0644 ./workload.jwt /run/swarm-external-secrets/workload.jwt
+
+docker plugin set swarm-external-secrets:latest \
+    SECRETS_PROVIDER="vault" \
+    VAULT_ADDR="https://vault.example.com:8200" \
+    VAULT_AUTH_METHOD="jwt" \
+    VAULT_JWT_ROLE="swarm-external-secrets" \
+    VAULT_JWT_FILE="/run/swarm-external-secrets/workload.jwt"
+```
+
+## JWT role and policy
+
+Enable JWT auth and create a role whose policies can read your KV secrets.
+The issued token must also be allowed to renew itself:
+
+```hcl
+path "secret/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+```
+
+Current Vault and OpenBao JWT auth reject identity tokens that omit **all** of
+`iat`, `nbf`, and `exp`. Include at least one (typically `iat` and `exp`) and
+match `iss`, `sub`, and `aud` to the role (`bound_issuer`, `bound_subject`,
+`bound_audiences`).
+
+A full local setup used by CI is in `scripts/tests/smoke-test-vault-jwt.sh` and
+`scripts/tests/smoke-test-openbao-jwt.sh` in this repository.
+
+## Client-token renewal
+
+After a successful AppRole or JWT login, Vault/OpenBao returns a **client
+token** with a TTL. The plugin renews that token; it does not mint a new
+identity JWT.
+
+| Auth method | Client-token renewal | Re-login when renew fails |
+|---|---|---|
+| `token` | No. A static `VAULT_TOKEN` / `OPENBAO_TOKEN` is used until it expires. | No |
+| `approle` | Yes | Yes (`role_id` / `secret_id`) |
+| `jwt` | Yes | Yes (same JWT, or a freshly read `*_JWT_FILE`) |
+
+When the issued token is renewable and has a positive TTL, a background worker:
+
+1. Waits until about **two-thirds** of the remaining lease TTL.
+2. Calls `auth/token/renew-self`.
+3. If renew fails (including when **max TTL** is reached), logs in again with
+   AppRole or JWT.
+4. If a secret read returns `401` or `403`, logs in again and retries the read.
+
+Retries after a failed renew use a 5s wait that doubles up to one minute.
+
+Look for these plugin log lines (`vault` or `openbao` depending on the
+provider):
+
+- `Successfully renewed vault token`
+- `Renewing vault token failed, attempting re-authentication`
+- `Successfully re-authenticated with vault`
+
+Enable `LOG_LEVEL=debug` (or `6`) if you need the debug-level renewal lines.
+
+!!! warning "Static tokens do not auto-renew"
+    `VAULT_AUTH_METHOD=token` (the default) never starts the renewal worker.
+    Use AppRole or JWT when the plugin must outlive a short-lived client token.
+
+!!! note "Secret rotation is separate"
+    `ENABLE_ROTATION` watches KV values and updates Swarm secrets. Token
+    renewal keeps the plugin authenticated. See [Secret rotation](rotation.md).
+
+## CI smoke tests
+
+The `smoke-test-jwt-renewal` job in `.github/workflows/smoke-tests.yml` runs
+the Vault and OpenBao JWT scripts with a 10s token TTL, 25s max TTL, and a 45s
+wait so CI asserts both renew-self and max-TTL re-login, then redeploys a
+stack to prove reads still work.

--- a/docs/multi-provider.md
+++ b/docs/multi-provider.md
@@ -15,9 +15,14 @@ The Vault Swarm Plugin supports multiple secrets providers, allowing you to use 
 | `VAULT_ADDR` | Vault server address | `http://localhost:8200` |
 | `VAULT_TOKEN` | Vault token for authentication | — |
 | `VAULT_MOUNT_PATH` | Mount path for KV engine | `secret` |
-| `VAULT_AUTH_METHOD` | Authentication method (`token`, `approle`) | `token` |
+| `VAULT_AUTH_METHOD` | Authentication method (`token`, `approle`, `jwt`) | `token` |
 | `VAULT_ROLE_ID` | Role ID for AppRole authentication | — |
 | `VAULT_SECRET_ID` | Secret ID for AppRole authentication | — |
+| `VAULT_APPROLE_AUTH_PATH` | AppRole auth mount path | `approle` |
+| `VAULT_JWT_ROLE` | JWT auth role name | — |
+| `VAULT_JWT` | Signed JWT (or use `VAULT_JWT_FILE`) | — |
+| `VAULT_JWT_FILE` | Path inside the plugin to a JWT file | — |
+| `VAULT_JWT_AUTH_PATH` | JWT auth mount path | `jwt` |
 | `VAULT_SKIP_VERIFY` | Skip TLS verification (not recommended for production) | `false` |
 
 **Example:**
@@ -26,6 +31,17 @@ docker plugin set swarm-external-secrets:latest \
     SECRETS_PROVIDER="vault" \
     VAULT_ADDR="https://vault.example.com:8200" \
     VAULT_TOKEN="hvs.example-token"
+```
+
+JWT authentication (client token is renewed; see [Vault and OpenBao JWT](jwt.md)):
+
+```bash
+docker plugin set swarm-external-secrets:latest \
+    SECRETS_PROVIDER="vault" \
+    VAULT_ADDR="https://vault.example.com:8200" \
+    VAULT_AUTH_METHOD="jwt" \
+    VAULT_JWT_ROLE="swarm-external-secrets" \
+    VAULT_JWT="<signed-jwt>"
 ```
 
 **Mount Path Behavior:**
@@ -115,9 +131,14 @@ docker plugin set swarm-external-secrets:latest \
 | `OPENBAO_ADDR` | OpenBao server address | `http://localhost:8200` |
 | `OPENBAO_TOKEN` | OpenBao token for authentication | — |
 | `OPENBAO_MOUNT_PATH` | Mount path for KV engine | `secret` |
-| `OPENBAO_AUTH_METHOD` | Authentication method (`token`, `approle`) | `token` |
+| `OPENBAO_AUTH_METHOD` | Authentication method (`token`, `approle`, `jwt`) | `token` |
 | `OPENBAO_ROLE_ID` | Role ID for AppRole authentication | — |
 | `OPENBAO_SECRET_ID` | Secret ID for AppRole authentication | — |
+| `OPENBAO_APPROLE_AUTH_PATH` | AppRole auth mount path | `approle` |
+| `OPENBAO_JWT_ROLE` | JWT auth role name | — |
+| `OPENBAO_JWT` | Signed JWT (or use `OPENBAO_JWT_FILE`) | — |
+| `OPENBAO_JWT_FILE` | Path inside the plugin to a JWT file | — |
+| `OPENBAO_JWT_AUTH_PATH` | JWT auth mount path | `jwt` |
 | `OPENBAO_SKIP_VERIFY` | Skip TLS verification (not recommended for production) | `false` |
 
 **Example:**
@@ -126,6 +147,17 @@ docker plugin set swarm-external-secrets:latest \
     SECRETS_PROVIDER="openbao" \
     OPENBAO_ADDR="https://openbao.example.com:8200" \
     OPENBAO_TOKEN="ob_example-token"
+```
+
+JWT authentication (client token is renewed; see [Vault and OpenBao JWT](jwt.md)):
+
+```bash
+docker plugin set swarm-external-secrets:latest \
+    SECRETS_PROVIDER="openbao" \
+    OPENBAO_ADDR="https://openbao.example.com:8200" \
+    OPENBAO_AUTH_METHOD="jwt" \
+    OPENBAO_JWT_ROLE="swarm-external-secrets" \
+    OPENBAO_JWT="<signed-jwt>"
 ```
 
 **Mount Path Behavior:**
@@ -381,6 +413,10 @@ secrets:
 
 ## Provider-Specific Notes
 
+### HashiCorp Vault
+- Supports token, AppRole, and JWT authentication
+- JWT and AppRole client tokens are renewed at about two-thirds of TTL; static tokens are not (see [Vault and OpenBao JWT](jwt.md))
+
 ### AWS Secrets Manager
 - Supports IAM roles, access keys, and profiles
 - JSON secrets are parsed automatically
@@ -394,7 +430,8 @@ secrets:
 ### OpenBao
 - Fully compatible with Vault API
 - Use for Vault migration or open-source requirements
-- Supports all Vault authentication methods
+- Supports token, AppRole, and JWT authentication
+- JWT and AppRole client tokens are renewed at about two-thirds of TTL; static tokens are not (see [Vault and OpenBao JWT](jwt.md))
 
 ### OCI Vault
 - Supports API key and instance principal authentication

--- a/docs/rotation.md
+++ b/docs/rotation.md
@@ -6,6 +6,10 @@ This document describes the automatic secret rotation feature of the Swarm Exter
 
 The plugin automatically monitors secrets in Vault and updates the corresponding Docker Swarm secrets and services when changes are detected. This ensures that applications always use the latest secret values without manual intervention.
 
+This is **secret value** rotation. Keeping the plugin logged in to Vault or OpenBao
+(AppRole/JWT client-token renew-self and re-login) is documented separately in
+[Vault and OpenBao JWT](jwt.md). A static `VAULT_TOKEN` is not renewed.
+
 ## How It Works
 
 1. **Secret Tracking**: When a Docker service requests a secret, the plugin tracks the mapping between the Docker secret and its corresponding Vault path.

--- a/docs/rotation.md
+++ b/docs/rotation.md
@@ -8,7 +8,8 @@ The plugin automatically monitors secrets in Vault and updates the corresponding
 
 This is **secret value** rotation. Keeping the plugin logged in to Vault or OpenBao
 (AppRole/JWT client-token renew-self and re-login) is documented separately in
-[Vault and OpenBao JWT](jwt.md). A static `VAULT_TOKEN` is not renewed.
+[Vault and OpenBao JWT](jwt.md). A static `VAULT_TOKEN` or `OPENBAO_TOKEN` is
+not renewed.
 
 ## How It Works
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - index.md
   - Providers:
       - GCP Secret Manager: gcp.md
+      - Vault and OpenBao JWT: jwt.md
   - Multi-Provider: multi-provider.md
   - Monitoring: monitoring.md
   - Rotation: rotation.md

--- a/readme.md
+++ b/readme.md
@@ -22,14 +22,14 @@ For more information, check out [GSoC Contribution Guidelines](./CONTRIBUTING.md
 
 ## Documentation
 
-Please refer to the [docs](https://sugar-org.github.io/swarm-external-secrets/) for more information.
+Please refer to the [docs](https://sugar-org.github.io/swarm-external-secrets/) for more information. JWT login and Vault/OpenBao client-token renewal are in `docs/jwt.md`.
 
 ## Supported Providers
 
 ## Features
 
 - **Multi-Provider Support**: HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, OpenBao, OCI Vault
-- **Multiple Auth Methods**: Support for various authentication methods per provider
+- **Multiple Auth Methods**: Token, AppRole, and JWT for Vault and OpenBao, including client-token renewal
 - **Automatic Secret Rotation**: Monitor providers for changes and automatically update Docker secrets and services
 - **Real-time Monitoring**: Web dashboard with system metrics, health status, and performance tracking
 - **Flexible Path Mapping**: Customize secret paths and field extraction per provider
@@ -168,10 +168,10 @@ docker plugin set swarm-external-secrets:latest \
 
 | Provider | Status | Authentication | Rotation |
 |----------|--------|---------------|----------|
-| HashiCorp Vault | ✅ Stable | Token, AppRole | ✅ |
+| HashiCorp Vault | ✅ Stable | Token, AppRole, JWT | ✅ |
 | AWS Secrets Manager | ✅ Stable | IAM, Access Keys | ✅ |
 | Azure Key Vault | ✅ Stable | Service Principal, Access Token | ✅ |
-| OpenBao | ✅ Stable | Token, AppRole | ✅ |
+| OpenBao | ✅ Stable | Token, AppRole, JWT | ✅ |
 | OCI Vault | 🚧 Beta | API Key, Instance Principal | ✅ |
 | GCP Secret Manager | 🚧 Placeholder | - | - |
 


### PR DESCRIPTION
## Summary
- Add `docs/jwt.md` covering JWT login (`VAULT_*` / `OPENBAO_*`), identity-token claims (`iat`/`nbf`/`exp`), `renew-self` policy, client-token renewal at ~2/3 TTL, and max-TTL re-login.
- Update env tables and examples in `docs/multi-provider.md`, the provider table in `readme.md`, plus pointers from debugging and secret-rotation docs so JWT renewal is not confused with KV rotation.
- Stacked on #197 (`ci/jwt-renewal-smoke`).

## Test plan
- [ ] MkDocs nav includes **Vault and OpenBao JWT** and the page renders.
- [ ] Env tables list `jwt` plus `*_JWT*` / `*_APPROLE_AUTH_PATH`.
- [ ] Docs state that static `VAULT_TOKEN` does not auto-renew, while AppRole and JWT do.


Made with [Cursor](https://cursor.com)