### PR TITLE
ci: skip test workflows on documentation-only changes

### DIFF
--- a/.github/workflows/aws-floci-tests.yml
+++ b/.github/workflows/aws-floci-tests.yml
@@ -2,8 +2,18 @@ name: AWS Floci Tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
   push:
     branches: [main, alpha/provider-integration]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
 
 jobs:
   aws-floci-tests:

--- a/.github/workflows/azure-floci-tests.yml
+++ b/.github/workflows/azure-floci-tests.yml
@@ -2,8 +2,18 @@ name: Azure Floci Tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
   push:
     branches: [main, alpha/provider-integration]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
 
 jobs:
   azure-floci-tests:

--- a/.github/workflows/gcp-floci-tests.yml
+++ b/.github/workflows/gcp-floci-tests.yml
@@ -2,8 +2,18 @@ name: GCP Floci Tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
   push:
     branches: [main, alpha/provider-integration]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
 
 jobs:
   gcp-floci-tests:

--- a/.github/workflows/lefthook.yml
+++ b/.github/workflows/lefthook.yml
@@ -3,7 +3,17 @@ name: lefthook pre validate
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/oci-floci-tests.yml
+++ b/.github/workflows/oci-floci-tests.yml
@@ -2,8 +2,18 @@ name: OCI Floci Tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
   push:
     branches: [main, alpha/provider-integration, feat/oci-provider]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
 
 jobs:
   # AWS-style: start the emulator and exercise Vault + KMS crypto + secret

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -2,8 +2,18 @@ name: Smoke Tests
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
 
 jobs:
   smoke-test:

--- a/.github/workflows/vet-ci.yml
+++ b/.github/workflows/vet-ci.yml
@@ -2,9 +2,19 @@ name: vet OSS Components
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
   push:
     branches:
       - main
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - "mkdocs.yml"
 
 permissions:
   # Required for actions/checkout@v4


### PR DESCRIPTION
## Summary
- Skip smoke, Floci (AWS/Azure/GCP/OCI), lefthook, and vet when a pull request or `main` push only changes documentation (`docs/**`, `*.md`, `mkdocs.yml`).
- Mixed docs + code changes still run the full test matrix.
- MkDocs (`Documentation` / `gen-docs`) still runs so docs PRs keep a real build check. Prow labeling, Scorecard, and GitHub apps (CodeQL, SonarCloud) are unchanged.

## Test plan
- [ ] This PR changes workflow YAML, so the test workflows **should still run** here (path filters only skip when *every* changed file is docs).
- [ ] After merge, a docs-only PR (for example an edit to `docs/jwt.md` or `readme.md`) should not start Smoke Tests, Floci, lefthook, or vet.
- [ ] A PR that touches Go or scripts plus markdown should still run those workflows.
- [ ] `Documentation` / `gen-docs` should still run on docs changes.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflows to skip runs when changes are limited to documentation, Markdown files, or the MkDocs configuration.
  - Applies consistently to pull requests and pushes across testing, smoke-test, linting, and validation workflows.
  - Reduces unnecessary workflow runs for documentation-only updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->