### PR TITLE
fix: point release dry-run at remote main

### DIFF
--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -17,14 +17,14 @@ elif [[ -n "${1:-}" ]]; then
   exit 2
 fi
 
-PREVIEW_BRANCH="makim-release-preview"
-WORKTREE=""
+ROOT="$(pwd)"
+WORKDIR=""
 
 cleanup() {
-  if [[ -n "${WORKTREE}" && -d "${WORKTREE}" ]]; then
-    git worktree remove --force "${WORKTREE}" >/dev/null 2>&1 || true
+  if [[ -n "${WORKDIR}" && -d "${WORKDIR}" ]]; then
+    rm -rf "${WORKDIR}"
   fi
-  git branch -D "${PREVIEW_BRANCH}" >/dev/null 2>&1 || true
+  git -C "${ROOT}" branch -D makim-release-preview >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -48,9 +48,16 @@ fi
 
 git fetch origin main --tags
 
-WORKTREE="$(mktemp -d)"
-git worktree add -B "${PREVIEW_BRANCH}" "${WORKTREE}" origin/main >/dev/null
-cd "${WORKTREE}"
+# semantic-release only accepts release branches that exist on the remote
+# (git ls-remote). A local preview branch is invisible to that check, and a
+# second worktree cannot check out main while this repo already has it.
+ORIGIN_URL="$(git remote get-url origin)"
+WORKDIR="$(mktemp -d)"
+git clone --quiet --local "${ROOT}" "${WORKDIR}"
+cd "${WORKDIR}"
+git remote set-url origin "${ORIGIN_URL}"
+git fetch origin main --tags
+git checkout -q -B main origin/main
 
 echo "Analyzing origin/main at $(git rev-parse --short HEAD) (latest tag: $(git describe --tags --abbrev=0))"
 
@@ -58,7 +65,7 @@ log="$(
   semantic_release \
     --dry-run \
     --no-ci \
-    --branches "${PREVIEW_BRANCH}" \
+    --branches main \
     --plugins @semantic-release/commit-analyzer \
     --verify-conditions "" \
     2>&1 | tee /dev/stderr


### PR DESCRIPTION
## Summary
- `makim release.dry-run` failed with `ERELEASEBRANCHES` because semantic-release 25 only accepts branches that exist on the remote (`git ls-remote`). The local `makim-release-preview` worktree was invisible to that check.
- Analyze `origin/main` in a local clone checked out as `main`, and pass `--branches main`.

## Test plan
- [x] `./scripts/cut-release.sh --dry-run` against current `origin/main` completes and reports no release-worthy commits since `v1.2.0` (`ci`/`docs`/`chore` only).
- [ ] After merge, `makim release.dry-run` from `main` should preview `v1.2.1` (this commit is a `fix:`).
- [ ] Do not run `makim release.cut` until that preview looks right.


Made with [Cursor](https://cursor.com)